### PR TITLE
Move Milltime to first position in side navigation menu

### DIFF
--- a/app/src/components/side-nav.tsx
+++ b/app/src/components/side-nav.tsx
@@ -20,16 +20,16 @@ import { NotificationsPopover } from "./notifications-popover/notifications-popo
 type LinkDestination = LinkProps<typeof router>["to"];
 const MENU_ITEMS = [
   {
-    title: "Pull requests",
-    icon: GitPullRequest,
-    variant: "ghost",
-    to: "/prs",
-  },
-  {
     title: "Milltime",
     icon: TimerIcon,
     variant: "ghost",
     to: "/milltime",
+  },
+  {
+    title: "Pull requests",
+    icon: GitPullRequest,
+    variant: "ghost",
+    to: "/prs",
   },
   {
     title: "Repositories",


### PR DESCRIPTION
This PR changes the order of menu items in the side navigation to show Milltime first, followed by Pull requests and Repositories.