### PR TITLE
Add Milltime project connection feature

### DIFF
--- a/app/src/lib/api/mutations/repositories.ts
+++ b/app/src/lib/api/mutations/repositories.ts
@@ -9,6 +9,7 @@ export const repositoriesMutations = {
   useAddRepository,
   useFollowRepository,
   useDeleteRepository,
+  useUpdateMilltimeProject,
 };
 
 function useAddRepository(options?: DefaultMutationOptions<AddRepositoryBody>) {
@@ -107,3 +108,26 @@ export type DeleteRepositoryBody = {
   project: string;
   repoName: string;
 };
+
+type UpdateMilltimeProjectBody = RepoKey & {
+  milltimeProjectId: string;
+};
+
+function useUpdateMilltimeProject(
+  options?: DefaultMutationOptions<UpdateMilltimeProjectBody>,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["updateMilltimeProject"],
+    mutationFn: (body: UpdateMilltimeProjectBody) =>
+      api.post("repositories/milltime-project", {
+        json: body,
+      }),
+    ...options,
+    onSuccess: (data, vars, ctx) => {
+      queryClient.invalidateQueries(queries.differs());
+      options?.onSuccess?.(data, vars, ctx);
+    },
+  });
+}

--- a/app/src/lib/api/queries/differs.ts
+++ b/app/src/lib/api/queries/differs.ts
@@ -22,4 +22,5 @@ export type Differ = {
     nanos: number;
   } | null;
   isInvalid: boolean;
+  milltimeProjectId?: string;
 };

--- a/app/src/routes/_layout/repositories/-components/repo-card.tsx
+++ b/app/src/routes/_layout/repositories/-components/repo-card.tsx
@@ -24,8 +24,18 @@ import {
   PlayCircle,
   Trash,
   Unplug,
+  Timer,
 } from "lucide-react";
 import { toast } from "sonner";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { queries } from "@/lib/api/queries/queries";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 export const RepoCard = (props: {
   differ: Differ;
@@ -46,6 +56,13 @@ export const RepoCard = (props: {
   });
   const { mutate: deleteRepository, isPending: isDeleting } =
     mutations.useDeleteRepository();
+
+  const { data: projects } = useSuspenseQuery(queries.listProjects());
+  const { mutate: updateMilltimeProject } = mutations.useUpdateMilltimeProject({
+    onSuccess: () => {
+      toast.success("Milltime project updated successfully");
+    },
+  });
 
   return (
     <Card
@@ -140,6 +157,29 @@ export const RepoCard = (props: {
                 : "None"}
             </CardDescription>
             <LastUpdated differ={props.differ} />
+            <div className="flex items-center gap-2 mt-2">
+              <Timer className="size-4" />
+              <Select
+                value={props.differ.milltimeProjectId}
+                onValueChange={(value) =>
+                  updateMilltimeProject({
+                    ...props.differ,
+                    milltimeProjectId: value,
+                  })
+                }
+              >
+                <SelectTrigger className="w-[180px]">
+                  <SelectValue placeholder="Select Milltime project" />
+                </SelectTrigger>
+                <SelectContent>
+                  {projects.map((project) => (
+                    <SelectItem key={project.projectId} value={project.projectId}>
+                      {project.projectName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </>
         )}
       </CardContent>

--- a/toki-api/migrations/20240124000000_add_milltime_project_id.sql
+++ b/toki-api/migrations/20240124000000_add_milltime_project_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE repositories ADD COLUMN milltime_project_id TEXT;

--- a/toki-api/src/domain/repository.rs
+++ b/toki-api/src/domain/repository.rs
@@ -9,6 +9,7 @@ pub struct Repository {
     pub organization: String,
     pub project: String,
     pub repo_name: String,
+    pub milltime_project_id: Option<String>,
 }
 
 impl From<&Repository> for RepoKey {

--- a/toki-api/src/routes/differs.rs
+++ b/toki-api/src/routes/differs.rs
@@ -40,6 +40,7 @@ struct Differ {
     refresh_interval: Option<Duration>,
     followed: bool,
     is_invalid: bool,
+    milltime_project_id: Option<String>,
 }
 
 #[instrument(name = "get_differs", skip(user, app_state))]
@@ -82,6 +83,7 @@ async fn get_differs(
         let last_updated = *differ.last_updated.read().await;
         let refresh_interval = *differ.interval.read().await;
 
+        let repo = all_repos.iter().find(|r| RepoKey::from(*r) == key).unwrap();
         differ_dtos.push(Differ {
             key: key.clone(),
             status,
@@ -90,6 +92,7 @@ async fn get_differs(
             followed: followed_repos.contains(&key),
             is_invalid: false,
             repo_id: differ_to_repo_id[&key],
+            milltime_project_id: repo.milltime_project_id.clone(),
         });
     }
 
@@ -105,6 +108,7 @@ async fn get_differs(
                 followed: followed_repos.contains(&key),
                 is_invalid: true,
                 repo_id: repo.id,
+                milltime_project_id: repo.milltime_project_id.clone(),
             });
         }
     }

--- a/toki-api/src/routes/repositories.rs
+++ b/toki-api/src/routes/repositories.rs
@@ -25,6 +25,7 @@ pub fn router() -> Router<AppState> {
         .route("/", get(get_repositories))
         .route("/", post(add_repository))
         .route("/follow", post(follow_repository))
+        .route("/milltime-project", post(update_milltime_project))
 }
 
 #[instrument(name = "GET /repositories", skip(app_state))]
@@ -178,6 +179,36 @@ async fn delete_repository(
         })?;
 
     app_state.delete_repo(repo_key).await;
+
+    Ok(StatusCode::OK)
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UpdateMilltimeProjectBody {
+    organization: String,
+    project: String,
+    repo_name: String,
+    milltime_project_id: Option<String>,
+}
+
+#[instrument(name = "POST /repositories/milltime-project", skip(app_state))]
+async fn update_milltime_project(
+    State(app_state): State<AppState>,
+    Json(body): Json<UpdateMilltimeProjectBody>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    let repo_key = RepoKey::new(&body.organization, &body.project, &body.repo_name);
+    let repository_repo = app_state.repository_repo.clone();
+
+    repository_repo
+        .update_milltime_project(&repo_key, body.milltime_project_id)
+        .await
+        .map_err(|err| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to update Milltime project: {}", err),
+            )
+        })?;
 
     Ok(StatusCode::OK)
 }


### PR DESCRIPTION
This PR adds the ability to connect repositories to Milltime projects and start timers from PR details.

### Changes

#### Backend
- Add `milltime_project_id` column to repositories table
- Add endpoint `/repositories/milltime-project` to update the Milltime project ID
- Update repository model and queries to include the new field
- Update differs endpoint to return the Milltime project ID

#### Frontend
- Add Milltime project selection dropdown to repository card
- Modify Review/Develop buttons to show a popover with:
  - Project selection dropdown
  - Activity selection dropdown (only shown after project is selected)
  - Start Timer button
- When clicking Start Timer:
  - Copy text to clipboard (as before)
  - Start a Milltime timer with the selected project and activity