### PR TITLE
feat: one-click Start again for time entries (issue #29)

### DIFF
--- a/app/src/components/milltime-timer-dialog.tsx
+++ b/app/src/components/milltime-timer-dialog.tsx
@@ -147,18 +147,18 @@ export const MilltimeTimerDialog = (props: {
             <TimerHistory
               className="mt-4"
               onHistoryClick={(timeEntry) => {
-                // already selected? start timer
-                if (
-                  timeEntry.projectName === selectedProject?.projectName &&
-                  timeEntry.activityName === selectedActivity?.activityName &&
-                  timeEntry.note === note
-                ) {
-                  startTimer();
-                } else {
-                  setProjectId(timeEntry.projectId);
-                  setActivityName(timeEntry.activityName);
-                  setNote(timeEntry.note);
-                }
+                // One-click start again
+                startTimerMutate({
+                  activity: timeEntry.activityName,
+                  activityName: timeEntry.activityName,
+                  projectId: timeEntry.projectId,
+                  projectName: timeEntry.projectName,
+                  userNote: timeEntry.note,
+                  regDay: dayjs().format("YYYY-MM-DD"),
+                  weekNumber: getWeekNumber(new Date()),
+                });
+                props.onOpenChange(false);
+                resetForm();
               }}
             />
           </div>

--- a/app/src/routes/_layout/milltime/-components/time-entries-list.tsx
+++ b/app/src/routes/_layout/milltime/-components/time-entries-list.tsx
@@ -9,7 +9,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { AttestLevel, TimeEntry } from "@/lib/api/queries/milltime";
-import { cn, formatHoursAsHoursMinutes } from "@/lib/utils";
+import { cn, formatHoursAsHoursMinutes, getWeekNumber } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -21,6 +21,7 @@ import {
   PencilIcon,
   SaveIcon,
   TrashIcon,
+  PlayCircleIcon,
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -253,6 +254,19 @@ function ViewEntryCard(props: {
   onEdit: () => void;
   overlapMap: Record<string, boolean>;
 }) {
+  const { mutate: startTimerMutate } = milltimeMutations.useStartTimer();
+  const handleStartAgain = () => {
+    if (isMergedTimeEntry(props.entry)) return; // ambiguous for merged entries
+    startTimerMutate({
+      activity: props.entry.activityName,
+      activityName: props.entry.activityName,
+      projectId: props.entry.projectId,
+      projectName: props.entry.projectName,
+      userNote: props.entry.note ?? "",
+      regDay: dayjs().format("YYYY-MM-DD"),
+      weekNumber: getWeekNumber(new Date()),
+    });
+  };
   return (
     <div>
       <div className="flex items-center justify-between gap-2">
@@ -337,6 +351,21 @@ function ViewEntryCard(props: {
               </Tooltip>
             ) : (
               <LockIcon className="size-4 text-muted-foreground" />
+            )}
+            {!isMergedTimeEntry(props.entry) && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={handleStartAgain}
+                    className="size-8"
+                  >
+                    <PlayCircleIcon className="size-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Start again</TooltipContent>
+              </Tooltip>
             )}
             {props.entry.endTime && (
               <p className="flex items-center gap-1 text-base text-muted-foreground">


### PR DESCRIPTION
## Summary
- Adds one-click 'Start again' action from timer history and time entries list.
- Uses existing start timer mutation to immediately create a new running timer with same project/activity/note.

Closes #29