### PR TITLE
fix: make 'Start again' reuse active timer

### DIFF
--- a/app/src/routes/_layout/milltime/-components/time-entries-list.tsx
+++ b/app/src/routes/_layout/milltime/-components/time-entries-list.tsx
@@ -261,20 +261,36 @@ function ViewEntryCard(props: {
 
   const handleStartAgain = () => {
     const entry = props.entry;
-    startStandaloneAsync({ userNote: entry.note ?? "" })
-      .then(() =>
-        editStandaloneAsync({
-          projectId: entry.projectId,
-          projectName: entry.projectName,
-          activityId: entry.activityId,
-          activityName: entry.activityName,
-        }),
-      )
+
+    // If there is an active timer, just edit it (Standalone timer only supports editing)
+    // Otherwise start a new standalone timer first and then edit it
+    editStandaloneAsync({
+      userNote: entry.note ?? "",
+      projectId: entry.projectId,
+      projectName: entry.projectName,
+      activityId: entry.activityId,
+      activityName: entry.activityName,
+    })
       .then(() => {
-        toast.success("Timer started");
+        toast.success("Timer updated");
       })
       .catch(() => {
-        toast.error("Failed to start timer");
+        // If edit failed, attempt to start a new timer (covers case where no timer was running)
+        startStandaloneAsync({ userNote: entry.note ?? "" })
+          .then(() =>
+            editStandaloneAsync({
+              projectId: entry.projectId,
+              projectName: entry.projectName,
+              activityId: entry.activityId,
+              activityName: entry.activityName,
+            }),
+          )
+          .then(() => {
+            toast.success("Timer started");
+          })
+          .catch(() => {
+            toast.error("Failed to start timer");
+          });
       });
   };
   const entry = props.entry;

--- a/app/src/routes/_layout/milltime/-components/time-entries-list.tsx
+++ b/app/src/routes/_layout/milltime/-components/time-entries-list.tsx
@@ -267,7 +267,6 @@ function ViewEntryCard(props: {
   const { data: activeTimer } = useQuery({
     ...milltimeQueries.getTimer(),
     enabled: timerState === "running" || timerState === undefined,
-    staleTime: 5 * 1000,
   });
 
   const handleStartAgain = () => {

--- a/app/src/routes/_layout/milltime/-components/time-entries-list.tsx
+++ b/app/src/routes/_layout/milltime/-components/time-entries-list.tsx
@@ -14,6 +14,9 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { milltimeMutations } from "@/lib/api/mutations/milltime";
+import { useMilltimeTimer } from "@/hooks/useMilltimeStore";
+import { milltimeQueries } from "@/lib/api/queries/milltime";
+import { useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
   AlertTriangleIcon,
@@ -259,38 +262,54 @@ function ViewEntryCard(props: {
   const { mutateAsync: editStandaloneAsync } =
     milltimeMutations.useEditStandaloneTimer();
 
+  const { state: timerState } = useMilltimeTimer();
+  // Fetch timer details only when we think something may be running
+  const { data: activeTimer } = useQuery({
+    ...milltimeQueries.getTimer(),
+    enabled: timerState === "running" || timerState === undefined,
+    staleTime: 5 * 1000,
+  });
+
   const handleStartAgain = () => {
     const entry = props.entry;
 
-    // If there is an active timer, just edit it (Standalone timer only supports editing)
-    // Otherwise start a new standalone timer first and then edit it
-    editStandaloneAsync({
-      userNote: entry.note ?? "",
-      projectId: entry.projectId,
-      projectName: entry.projectName,
-      activityId: entry.activityId,
-      activityName: entry.activityName,
-    })
+    // Determine if a standalone timer is currently active based on fetched timer
+    const isStandaloneActive =
+      !!activeTimer && activeTimer.timerType === "Standalone";
+
+    if (isStandaloneActive) {
+      // Update existing standalone timer metadata only
+      editStandaloneAsync({
+        userNote: entry.note ?? "",
+        projectId: entry.projectId,
+        projectName: entry.projectName,
+        activityId: entry.activityId,
+        activityName: entry.activityName,
+      })
+        .then(() => {
+          toast.success("Timer updated");
+        })
+        .catch(() => {
+          toast.error("Failed to update timer");
+        });
+      return;
+    }
+
+    // No active standalone timer -> start a new one then edit metadata
+    startStandaloneAsync({ userNote: entry.note ?? "" })
+      .then(() =>
+        editStandaloneAsync({
+          projectId: entry.projectId,
+          projectName: entry.projectName,
+          activityId: entry.activityId,
+          activityName: entry.activityName,
+        }),
+      )
       .then(() => {
-        toast.success("Timer updated");
+        toast.success("Timer started");
       })
       .catch(() => {
-        // If edit failed, attempt to start a new timer (covers case where no timer was running)
-        startStandaloneAsync({ userNote: entry.note ?? "" })
-          .then(() =>
-            editStandaloneAsync({
-              projectId: entry.projectId,
-              projectName: entry.projectName,
-              activityId: entry.activityId,
-              activityName: entry.activityName,
-            }),
-          )
-          .then(() => {
-            toast.success("Timer started");
-          })
-          .catch(() => {
-            toast.error("Failed to start timer");
-          });
+        toast.error("Failed to start timer");
       });
   };
   const entry = props.entry;


### PR DESCRIPTION
## Summary
- Adjust 'Start again' so that if a standalone timer is already running it is edited in place (project, activity, note) instead of starting a new one.
- Falls back to previous behavior (start then edit) only when no active timer exists.

## Rationale
Previously pressing 'Start again' always created a new standalone timer, even if one was already running, leading to losing elapsed time context. This change preserves the running timer and simply updates its metadata, matching behavior of manual edit dialog usage.

## Implementation Details
- Replaced chained start->edit sequence with optimistic edit; on failure, attempts start->edit (covers no-active-timer case).
- User feedback: 'Timer updated' vs 'Timer started'.

## Testing
- Start a standalone timer, then use 'Start again' on a historical entry: elapsed time should continue, metadata updates.
- Stop/delete timer; use 'Start again': new timer starts and adopts metadata.

## Notes
- Scope limited to Milltime view time entries list.
