### PR TITLE
support custom avatars

### DIFF
--- a/.sqlx/query-04c8c52260afee0e9406e2529f7c8d3a0ba771673818cb33460391a2e27d545d.json
+++ b/.sqlx/query-04c8c52260afee0e9406e2529f7c8d3a0ba771673818cb33460391a2e27d545d.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                users.id as \"id!\",\n                lower(users.email) as \"email!\",\n                user_avatars.updated_at as \"updated_at!\"\n            FROM users\n            INNER JOIN user_avatars ON user_avatars.user_id = users.id\n            WHERE lower(users.email) = ANY($1)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "email!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "updated_at!",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "04c8c52260afee0e9406e2529f7c8d3a0ba771673818cb33460391a2e27d545d"
+}

--- a/.sqlx/query-42fb2fff5abb2076d7479f48b6a0aa44d149c87054e3ac6acbc36b3e3ab8fd46.json
+++ b/.sqlx/query-42fb2fff5abb2076d7479f48b6a0aa44d149c87054e3ac6acbc36b3e3ab8fd46.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            DELETE FROM user_avatars\n            WHERE user_id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "42fb2fff5abb2076d7479f48b6a0aa44d149c87054e3ac6acbc36b3e3ab8fd46"
+}

--- a/.sqlx/query-69393b1bdacd9c0bc373352b790e066e7c9f26269b99eeae7d14e0e6df9e4491.json
+++ b/.sqlx/query-69393b1bdacd9c0bc373352b790e066e7c9f26269b99eeae7d14e0e6df9e4491.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT image, mime_type\n            FROM user_avatars\n            WHERE user_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "image",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 1,
+        "name": "mime_type",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "69393b1bdacd9c0bc373352b790e066e7c9f26269b99eeae7d14e0e6df9e4491"
+}

--- a/.sqlx/query-9c50b069885ce4e140b03e92cdd635fdb1d5d333b24505b61a3d696897a4a43e.json
+++ b/.sqlx/query-9c50b069885ce4e140b03e92cdd635fdb1d5d333b24505b61a3d696897a4a43e.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO user_avatars (user_id, image, mime_type, updated_at)\n            VALUES ($1, $2, $3, now())\n            ON CONFLICT (user_id) DO UPDATE\n            SET image = EXCLUDED.image,\n                mime_type = EXCLUDED.mime_type,\n                updated_at = now()\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Bytea",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9c50b069885ce4e140b03e92cdd635fdb1d5d333b24505b61a3d696897a4a43e"
+}

--- a/.sqlx/query-c1afd66b83dd978611e854d164dad2b0a1a895dd7c8478159020134511d578d7.json
+++ b/.sqlx/query-c1afd66b83dd978611e854d164dad2b0a1a895dd7c8478159020134511d578d7.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT updated_at\n            FROM user_avatars\n            WHERE user_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c1afd66b83dd978611e854d164dad2b0a1a895dd7c8478159020134511d578d7"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,10 +104,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "async-channel"
@@ -158,6 +208,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,6 +271,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -382,6 +476,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0669d5a35b64fdb5ab7fb19cae13148b6b5cbdf4b8247faf54ece47f699c8cef"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitstream-io"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+dependencies = [
+ "core2",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,16 +515,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -436,6 +563,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -481,6 +610,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,7 +650,7 @@ dependencies = [
  "async-trait",
  "convert_case",
  "json5",
- "nom",
+ "nom 7.1.3",
  "pathdiff",
  "ron",
  "rust-ini",
@@ -622,6 +757,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,7 +867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -735,7 +879,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -990,7 +1134,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1003,6 +1147,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1060,6 +1224,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1075,12 +1254,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1324,13 +1532,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1370,6 +1594,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1852,6 +2087,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core 0.5.1",
+ "zune-jpeg 0.5.12",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +2165,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1945,10 +2231,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1988,7 +2293,7 @@ dependencies = [
  "k256",
  "p256",
  "p384",
- "rand",
+ "rand 0.8.5",
  "rsa 0.7.2",
  "serde",
  "serde_json",
@@ -2021,10 +2326,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libm"
@@ -2061,6 +2382,16 @@ checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libwebp-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54cd30df7c7165ce74a456e4ca9732c603e8dc5e60784558c1c6dc047f876733"
+dependencies = [
+ "cc",
+ "glob",
 ]
 
 [[package]]
@@ -2104,6 +2435,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,6 +2457,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
 
 [[package]]
 name = "md-5"
@@ -2215,6 +2565,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,6 +2609,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,12 +2625,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2278,7 +2669,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -2288,6 +2679,17 @@ name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "num-integer"
@@ -2305,6 +2707,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2338,7 +2751,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http 0.2.12",
- "rand",
+ "rand 0.8.5",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -2466,6 +2879,18 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pathdiff"
@@ -2643,6 +3068,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,6 +3157,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2733,6 +3190,30 @@ dependencies = [
  "idna 1.1.0",
  "psl-types",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -2756,8 +3237,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2767,7 +3258,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2777,6 +3278,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2947,6 +3527,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3005,7 +3591,7 @@ dependencies = [
  "num-traits",
  "pkcs1 0.4.1",
  "pkcs8 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "signature 1.6.4",
  "smallvec",
  "subtle",
@@ -3025,7 +3611,7 @@ dependencies = [
  "num-traits",
  "pkcs1 0.7.5",
  "pkcs8 0.10.2",
- "rand_core",
+ "rand_core 0.6.4",
  "signature 2.2.0",
  "spki 0.7.3",
  "subtle",
@@ -3404,7 +3990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3414,7 +4000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3422,6 +4008,15 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
 
 [[package]]
 name = "slab"
@@ -3615,7 +4210,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa 0.9.10",
  "serde",
  "sha1",
@@ -3654,7 +4249,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -3914,6 +4509,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg 0.4.21",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3998,7 +4607,8 @@ dependencies = [
  "dotenvy",
  "futures",
  "futures-util",
- "itertools",
+ "image",
+ "itertools 0.13.0",
  "milltime",
  "oauth2",
  "reqwest 0.12.28",
@@ -4019,6 +4629,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "web-push",
+ "webp",
 ]
 
 [[package]]
@@ -4271,7 +4882,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4409,7 +5020,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -4458,7 +5069,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -4483,7 +5094,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.17",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -4615,6 +5226,17 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -4786,6 +5408,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "webp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c071456adef4aca59bf6a583c46b90ff5eb0b4f758fc347cea81290288f37ce1"
+dependencies = [
+ "image",
+ "libwebp-sys",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4808,6 +5440,12 @@ checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
 name = "whoami"
@@ -5152,6 +5790,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yaml-rust2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5270,3 +5914,42 @@ name = "zmij"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "410e9ecef634c709e3831c2cfdb8d9c32164fae1c67496d5b68fff728eec37fe"
+dependencies = [
+ "zune-core 0.5.1",
+]

--- a/app/src/components/azure-avatar.tsx
+++ b/app/src/components/azure-avatar.tsx
@@ -1,23 +1,44 @@
+import * as React from "react";
 import { User } from "@/lib/api/queries/pullRequests";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
+import { useAtomValue } from "jotai/react";
+import { enablePokemonAvatarFallbackAtom } from "@/lib/avatar-preferences";
+import { useAvatarSourceWithFallback } from "@/hooks/useAvatarSourceWithFallback";
+import { useTheme } from "@/hooks/useTheme";
+import {
+  avatarFallbackTextColorFromSeed,
+  avatarRingColorFromSeed,
+  buildAvatarSources,
+  pokemonAvatarUrlFromSeed,
+} from "@/lib/avatar";
 
 export function AzureAvatar({
   user,
   disableTooltip,
   className,
+  overrideAvatarUrl,
 }: {
   user: User;
   disableTooltip?: boolean;
   className?: string;
+  overrideAvatarUrl?: string;
 }) {
   return disableTooltip ? (
-    <AvatarComponent user={user} className={className} />
+    <AvatarComponent
+      user={user}
+      className={className}
+      overrideAvatarUrl={overrideAvatarUrl}
+    />
   ) : (
     <Tooltip>
       <TooltipTrigger>
-        <AvatarComponent user={user} className={className} />
+        <AvatarComponent
+          user={user}
+          className={className}
+          overrideAvatarUrl={overrideAvatarUrl}
+        />
       </TooltipTrigger>
       <TooltipContent>
         <div className="text-sm font-medium">{user.displayName}</div>
@@ -26,11 +47,78 @@ export function AzureAvatar({
   );
 }
 
-function AvatarComponent(props: { user: User; className?: string }) {
+function AvatarComponent(props: {
+  user: User;
+  className?: string;
+  overrideAvatarUrl?: string;
+}) {
+  const { resolvedTheme } = useTheme();
+  const enablePokemonAvatarFallback = useAtomValue(
+    enablePokemonAvatarFallbackAtom,
+  );
+  const pokemonAvatarSrc = React.useMemo(
+    () =>
+      enablePokemonAvatarFallback
+        ? pokemonAvatarUrlFromSeed(props.user.uniqueName)
+        : undefined,
+    [enablePokemonAvatarFallback, props.user.uniqueName],
+  );
+
+  const avatarSources = React.useMemo(
+    () => buildAvatarSources({
+      preferredSources: [props.overrideAvatarUrl, props.user.avatarUrl],
+      pokemonSeed: props.user.uniqueName,
+      enablePokemonFallback: enablePokemonAvatarFallback,
+    }),
+    [
+      props.overrideAvatarUrl,
+      props.user.avatarUrl,
+      props.user.uniqueName,
+      enablePokemonAvatarFallback,
+    ],
+  );
+  const { avatarSrc, onLoadingStatusChange, failedSources } =
+    useAvatarSourceWithFallback(avatarSources);
+
+  const remainingSourceCount = React.useMemo(
+    () => avatarSources.filter((source) => !failedSources.has(source)).length,
+    [avatarSources, failedSources],
+  );
+  const isLetterFallbackActive =
+    avatarSources.length === 0 || remainingSourceCount === 0;
+  const isPokemonFallbackActive =
+    !!pokemonAvatarSrc &&
+    avatarSrc === pokemonAvatarSrc &&
+    !failedSources.has(pokemonAvatarSrc);
+  const pokemonRingColor = React.useMemo(
+    () => avatarRingColorFromSeed(props.user.uniqueName, resolvedTheme),
+    [props.user.uniqueName, resolvedTheme],
+  );
+  const fallbackInitialColor = React.useMemo(
+    () => avatarFallbackTextColorFromSeed(props.user.uniqueName, resolvedTheme),
+    [props.user.uniqueName, resolvedTheme],
+  );
+  const fallbackInitial = props.user.displayName?.[0]?.toUpperCase() ?? "?";
+
   return (
-    <Avatar className={cn("size-6", props.className)}>
-      <AvatarImage src={props.user.avatarUrl} alt={props.user.displayName} />
-      <AvatarFallback>{props.user.displayName[0].toUpperCase()}</AvatarFallback>
+    <Avatar
+      className={cn("size-[26px]", props.className)}
+      style={
+        isPokemonFallbackActive
+          ? { boxShadow: `inset 0 0 0 2px ${pokemonRingColor}` }
+          : undefined
+      }
+    >
+      <AvatarImage
+        src={avatarSrc}
+        alt={props.user.displayName}
+        onLoadingStatusChange={onLoadingStatusChange}
+      />
+      <AvatarFallback
+        style={isLetterFallbackActive ? { color: fallbackInitialColor } : undefined}
+      >
+        {fallbackInitial}
+      </AvatarFallback>
     </Avatar>
   );
 }

--- a/app/src/components/ui/input.tsx
+++ b/app/src/components/ui/input.tsx
@@ -11,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/app/src/hooks/useAvatarSourceWithFallback.ts
+++ b/app/src/hooks/useAvatarSourceWithFallback.ts
@@ -1,0 +1,41 @@
+import * as React from "react";
+
+type AvatarLoadingStatus = "idle" | "loading" | "loaded" | "error";
+
+export function useAvatarSourceWithFallback(sources: string[]) {
+  const [failedSources, setFailedSources] = React.useState<Set<string>>(
+    () => new Set(),
+  );
+
+  React.useEffect(() => {
+    setFailedSources(new Set());
+  }, [sources]);
+
+  const avatarSrc = React.useMemo(
+    () =>
+      sources.find((source) => !failedSources.has(source)) ??
+      sources[sources.length - 1],
+    [sources, failedSources],
+  );
+
+  const onLoadingStatusChange = React.useCallback(
+    (status: AvatarLoadingStatus) => {
+      if (status !== "error" || !avatarSrc) {
+        return;
+      }
+
+      setFailedSources((prev) => {
+        if (prev.has(avatarSrc)) {
+          return prev;
+        }
+
+        const next = new Set(prev);
+        next.add(avatarSrc);
+        return next;
+      });
+    },
+    [avatarSrc],
+  );
+
+  return { avatarSrc, onLoadingStatusChange, failedSources };
+}

--- a/app/src/lib/api/mutations/mutations.ts
+++ b/app/src/lib/api/mutations/mutations.ts
@@ -2,6 +2,7 @@ import { MutationOptions } from "@tanstack/react-query";
 import { differsMutations } from "./differs";
 import { repositoriesMutations } from "./repositories";
 import { timeTrackingMutations } from "./time-tracking";
+import { userMutations } from "./user";
 
 export type DefaultMutationOptions<
   TVars = void,
@@ -17,4 +18,5 @@ export const mutations = {
   ...differsMutations,
   ...repositoriesMutations,
   ...timeTrackingMutations,
+  ...userMutations,
 };

--- a/app/src/lib/api/mutations/user.ts
+++ b/app/src/lib/api/mutations/user.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "../api";
+import { pullRequestsQueries } from "../queries/pullRequests";
+import type { DefaultMutationOptions } from "./mutations";
+
+export type UploadAvatarVars = { file: File };
+
+export const userMutations = {
+  useUploadAvatar,
+  useDeleteAvatar,
+};
+
+export function useUploadAvatar(
+  options?: DefaultMutationOptions<UploadAvatarVars>,
+) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["user", "avatar", "upload"],
+    mutationFn: async ({ file }: UploadAvatarVars) => {
+      const formData = new FormData();
+      formData.append("avatar", file);
+      return api.post("users/me/avatar", { body: formData });
+    },
+    ...options,
+    onSuccess: (data, vars, ctx) => {
+      queryClient.invalidateQueries({ queryKey: ["me"] });
+      queryClient.invalidateQueries({ queryKey: pullRequestsQueries.baseKey });
+      options?.onSuccess?.(data, vars, ctx);
+    },
+  });
+}
+
+export function useDeleteAvatar(options?: DefaultMutationOptions<void>) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ["user", "avatar", "delete"],
+    mutationFn: async () => api.delete("users/me/avatar"),
+    ...options,
+    onSuccess: (data, vars, ctx) => {
+      queryClient.invalidateQueries({ queryKey: ["me"] });
+      queryClient.invalidateQueries({ queryKey: pullRequestsQueries.baseKey });
+      options?.onSuccess?.(data, vars, ctx);
+    },
+  });
+}

--- a/app/src/lib/api/queries/pullRequests.ts
+++ b/app/src/lib/api/queries/pullRequests.ts
@@ -37,6 +37,7 @@ export type ListPullRequest = {
   approvedBy: Reviewer[];
   waitingForUserReview: boolean;
   reviewRequired: boolean;
+  avatarOverrides: AvatarOverride[];
 };
 
 export type PullRequest = {
@@ -71,6 +72,11 @@ export type User = {
   id: string;
   displayName: string;
   uniqueName: string;
+  avatarUrl: string;
+};
+
+export type AvatarOverride = {
+  email: string;
   avatarUrl: string;
 };
 

--- a/app/src/lib/api/queries/user.ts
+++ b/app/src/lib/api/queries/user.ts
@@ -18,4 +18,5 @@ export type User = {
   picture: string;
   accessToken: string;
   roles: Role[];
+  avatarUrl: string | null;
 };

--- a/app/src/lib/avatar-preferences.ts
+++ b/app/src/lib/avatar-preferences.ts
@@ -1,0 +1,6 @@
+import { atomWithStorage } from "jotai/utils";
+
+export const enablePokemonAvatarFallbackAtom = atomWithStorage(
+  "avatar-enablePokemonFallback",
+  false,
+);

--- a/app/src/lib/avatar.ts
+++ b/app/src/lib/avatar.ts
@@ -1,0 +1,196 @@
+export const POKEMON_MAX_ID = 649;
+const POKEMON_SPRITE_BASE_URL =
+  "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork";
+const FALLBACK_AVATAR_SEED = "unknown-user";
+
+export function normalizeAvatarSeed(seed?: string | null): string {
+  const normalized = seed?.trim().toLowerCase();
+  return normalized && normalized.length > 0
+    ? normalized
+    : FALLBACK_AVATAR_SEED;
+}
+
+// Lightweight deterministic hash for stable avatar selection.
+export function hashSeedToUint32(seed: string): number {
+  let hash = 2166136261;
+
+  for (let i = 0; i < seed.length; i += 1) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+}
+
+export function pokemonIdFromSeed(
+  seed?: string | null,
+  max = POKEMON_MAX_ID,
+): number {
+  const boundedMax = Number.isFinite(max) && max > 0 ? Math.floor(max) : POKEMON_MAX_ID;
+  const normalizedSeed = normalizeAvatarSeed(seed);
+  const hash = hashSeedToUint32(normalizedSeed);
+
+  return (hash % boundedMax) + 1;
+}
+
+export function pokemonAvatarUrlFromSeed(seed?: string | null): string {
+  const pokemonId = pokemonIdFromSeed(seed);
+  return `${POKEMON_SPRITE_BASE_URL}/${pokemonId}.png`;
+}
+
+export function avatarHueFromSeed(seed?: string | null): number {
+  const normalizedSeed = normalizeAvatarSeed(seed);
+  const hash = hashSeedToUint32(normalizedSeed);
+  return hash % 360;
+}
+
+export type AvatarThemeMode = "light" | "dark";
+
+function hslToRgbNormalized(hue: number, saturation: number, lightness: number) {
+  const h = ((hue % 360) + 360) % 360;
+  const s = Math.min(Math.max(saturation, 0), 100) / 100;
+  const l = Math.min(Math.max(lightness, 0), 100) / 100;
+
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+
+  let rPrime = 0;
+  let gPrime = 0;
+  let bPrime = 0;
+
+  if (h < 60) {
+    rPrime = c;
+    gPrime = x;
+  } else if (h < 120) {
+    rPrime = x;
+    gPrime = c;
+  } else if (h < 180) {
+    gPrime = c;
+    bPrime = x;
+  } else if (h < 240) {
+    gPrime = x;
+    bPrime = c;
+  } else if (h < 300) {
+    rPrime = x;
+    bPrime = c;
+  } else {
+    rPrime = c;
+    bPrime = x;
+  }
+
+  return {
+    r: rPrime + m,
+    g: gPrime + m,
+    b: bPrime + m,
+  };
+}
+
+function toLinearRgb(channel: number): number {
+  return channel <= 0.03928
+    ? channel / 12.92
+    : ((channel + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(rgb: { r: number; g: number; b: number }): number {
+  const r = toLinearRgb(rgb.r);
+  const g = toLinearRgb(rgb.g);
+  const b = toLinearRgb(rgb.b);
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(foregroundLuminance: number, backgroundLuminance: number): number {
+  const light = Math.max(foregroundLuminance, backgroundLuminance);
+  const dark = Math.min(foregroundLuminance, backgroundLuminance);
+  return (light + 0.05) / (dark + 0.05);
+}
+
+function avatarAccentHslFromSeed(
+  seed: string | null | undefined,
+  mode: AvatarThemeMode,
+): {
+  hue: number;
+  saturation: number;
+  lightness: number;
+} {
+  const hue = avatarHueFromSeed(seed);
+  const saturation = mode === "light" ? 70 : 72;
+  const targetBackground = mode === "light"
+    ? hslToRgbNormalized(34, 7, 91)
+    : hslToRgbNormalized(222, 18, 14);
+  const targetBackgroundLuminance = relativeLuminance(targetBackground);
+  const minimumContrast = 4.5;
+
+  let lightness = mode === "light" ? 36 : 68;
+  const direction = mode === "light" ? -1 : 1;
+
+  for (let i = 0; i < 40; i += 1) {
+    const rgb = hslToRgbNormalized(hue, saturation, lightness);
+    const luminance = relativeLuminance(rgb);
+    const contrast = contrastRatio(luminance, targetBackgroundLuminance);
+
+    if (contrast >= minimumContrast) {
+      break;
+    }
+
+    lightness = Math.min(Math.max(lightness + direction, 0), 100);
+  }
+
+  return { hue, saturation, lightness };
+}
+
+export function avatarRingColorFromSeed(
+  seed: string | null | undefined,
+  mode: AvatarThemeMode,
+  alpha = 0.45,
+): string {
+  const boundedAlpha = Number.isFinite(alpha)
+    ? Math.min(Math.max(alpha, 0), 1)
+    : 0.45;
+  const { hue, saturation, lightness } = avatarAccentHslFromSeed(seed, mode);
+
+  return `hsla(${hue}, ${saturation}%, ${lightness}%, ${boundedAlpha})`;
+}
+
+export function avatarFallbackTextColorFromSeed(
+  seed: string | null | undefined,
+  mode: AvatarThemeMode,
+): string {
+  const { hue, saturation, lightness } = avatarAccentHslFromSeed(seed, mode);
+
+  return `hsl(${hue} ${saturation}% ${lightness}%)`;
+}
+
+export function uniqueAvatarSources(
+  sources: Array<string | null | undefined>,
+): string[] {
+  const unique = new Set<string>();
+
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+
+    const trimmed = source.trim();
+    if (!trimmed || unique.has(trimmed)) {
+      continue;
+    }
+
+    unique.add(trimmed);
+  }
+
+  return Array.from(unique);
+}
+
+export function buildAvatarSources(options: {
+  preferredSources: Array<string | null | undefined>;
+  pokemonSeed?: string | null;
+  enablePokemonFallback: boolean;
+}): string[] {
+  return uniqueAvatarSources([
+    ...options.preferredSources,
+    options.enablePokemonFallback
+      ? pokemonAvatarUrlFromSeed(options.pokemonSeed)
+      : null,
+  ]);
+}

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -1,6 +1,7 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { RepoKey } from "./api/queries/queries";
+import { AvatarOverride } from "./api/queries/pullRequests";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -69,4 +70,11 @@ export function formatHoursMinutes(hours: number) {
   const formattedMins = String(mins).padStart(2, "0");
 
   return `${isNegative ? "-" : ""}${formattedHrs}:${formattedMins}`;
+}
+
+export function buildAvatarOverrideMap(overrides: AvatarOverride[]) {
+  return overrides.reduce<Record<string, string>>((acc, override) => {
+    acc[override.email.toLowerCase()] = override.avatarUrl;
+    return acc;
+  }, {});
 }

--- a/app/src/routes/_layout/prs/-components/columns.tsx
+++ b/app/src/routes/_layout/prs/-components/columns.tsx
@@ -16,8 +16,10 @@ import {
   UserXIcon,
   ClockAlertIcon,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { buildAvatarOverrideMap, cn } from "@/lib/utils";
 import { StatusIcon } from "./status-icon";
+
+const avatarOverrideMapCache = new WeakMap<ListPullRequest, Record<string, string>>();
 
 export function pullRequestColumns(): ColumnDef<ListPullRequest>[] {
   return [
@@ -94,10 +96,18 @@ export function pullRequestColumns(): ColumnDef<ListPullRequest>[] {
           displayName.length > LIMIT
             ? displayName.slice(0, LIMIT) + "..."
             : displayName;
+        const avatarOverrideMap = getAvatarOverrideMap(row.original);
+        const authorOverride = resolveAvatarOverride(
+          row.original.createdBy.uniqueName,
+          avatarOverrideMap,
+        );
 
         return (
           <div className="flex flex-row items-center justify-center gap-2 2xl:justify-start">
-            <AzureAvatar user={row.original.createdBy} />
+            <AzureAvatar
+              user={row.original.createdBy}
+              overrideAvatarUrl={authorOverride}
+            />
             <span className="hidden text-nowrap 2xl:block">
               <ConditionalTooltip
                 condition={displayName.length > LIMIT}
@@ -185,6 +195,7 @@ export function pullRequestColumns(): ColumnDef<ListPullRequest>[] {
 
         const waitingForYourReview = row.original.waitingForUserReview;
         const reviewRequired = row.original.reviewRequired;
+        const avatarOverrideMap = getAvatarOverrideMap(row.original);
 
         return (
           <div className="flex flex-row items-center gap-2">
@@ -193,6 +204,10 @@ export function pullRequestColumns(): ColumnDef<ListPullRequest>[] {
                 key={reviewer.identity.id}
                 user={reviewer.identity}
                 className="border-2 border-green-600"
+                overrideAvatarUrl={resolveAvatarOverride(
+                  reviewer.identity.uniqueName,
+                  avatarOverrideMap,
+                )}
               />
             ))}
             {blockedBy.map((reviewer) => (
@@ -200,6 +215,10 @@ export function pullRequestColumns(): ColumnDef<ListPullRequest>[] {
                 key={reviewer.identity.id}
                 user={reviewer.identity}
                 className="border-2 border-red-600"
+                overrideAvatarUrl={resolveAvatarOverride(
+                  reviewer.identity.uniqueName,
+                  avatarOverrideMap,
+                )}
               />
             ))}
             {waitingForYourReview && (
@@ -245,4 +264,24 @@ export function pullRequestColumns(): ColumnDef<ListPullRequest>[] {
       },
     },
   ];
+}
+
+function resolveAvatarOverride(
+  uniqueName: string,
+  avatarOverrides: Record<string, string>,
+) {
+  return avatarOverrides[uniqueName.toLowerCase()];
+}
+
+function getAvatarOverrideMap(
+  pullRequest: ListPullRequest,
+): Record<string, string> {
+  const cached = avatarOverrideMapCache.get(pullRequest);
+  if (cached) {
+    return cached;
+  }
+
+  const avatarOverrideMap = buildAvatarOverrideMap(pullRequest.avatarOverrides);
+  avatarOverrideMapCache.set(pullRequest, avatarOverrideMap);
+  return avatarOverrideMap;
 }

--- a/app/src/routes/_layout/prs/-components/pr-card-list.tsx
+++ b/app/src/routes/_layout/prs/-components/pr-card-list.tsx
@@ -1,5 +1,6 @@
 import { AzureAvatar } from "@/components/azure-avatar";
 import { ListPullRequest } from "@/lib/api/queries/pullRequests";
+import { buildAvatarOverrideMap } from "@/lib/utils";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { CopySlashIcon, PickaxeIcon } from "lucide-react";
@@ -12,63 +13,73 @@ export function PrCardList(props: {
 }) {
   return (
     <div className="flex flex-col gap-2">
-      {props.data.map((pr) => (
-        <button
-          type="button"
-          key={pr.id}
-          onClick={() => props.onCardClick(pr)}
-          className="flex flex-col gap-1.5 overflow-hidden rounded-lg border border-border/50 bg-card/50 p-3 text-left transition-colors hover:bg-card active:bg-card/80"
-        >
-          {/* Row 1: Avatar + Title + Status icons */}
-          <div className="flex items-start gap-2">
-            <AzureAvatar
-              user={pr.createdBy}
-              className="mt-0.5 size-6 shrink-0"
-            />
-            <span className="min-w-0 flex-1 truncate text-sm font-medium">
-              {pr.title}
-            </span>
-            <div className="flex shrink-0 items-center gap-1">
-              {pr.isDraft && (
-                <PickaxeIcon className="size-4 text-blue-400" />
-              )}
-              {pr.mergeStatus === "conflicts" && (
-                <CopySlashIcon className="size-4 text-red-400" />
-              )}
+      {props.data.map((pr) => {
+        const avatarOverrideMap = buildAvatarOverrideMap(pr.avatarOverrides);
+        return (
+          <button
+            type="button"
+            key={pr.id}
+            onClick={() => props.onCardClick(pr)}
+            className="flex flex-col gap-1.5 overflow-hidden rounded-lg border border-border/50 bg-card/50 p-3 text-left transition-colors hover:bg-card active:bg-card/80"
+          >
+            {/* Row 1: Avatar + Title + Status icons */}
+            <div className="flex items-start gap-2">
+              <AzureAvatar
+                user={pr.createdBy}
+                className="mt-0.5 size-[26px] shrink-0"
+                overrideAvatarUrl={
+                  avatarOverrideMap[pr.createdBy.uniqueName.toLowerCase()]
+                }
+              />
+              <span className="min-w-0 flex-1 truncate text-sm font-medium">
+                {pr.title}
+              </span>
+              <div className="flex shrink-0 items-center gap-1">
+                {pr.isDraft && <PickaxeIcon className="size-4 text-blue-400" />}
+                {pr.mergeStatus === "conflicts" && (
+                  <CopySlashIcon className="size-4 text-red-400" />
+                )}
+              </div>
             </div>
-          </div>
 
-          {/* Row 2: Repo + Time */}
-          <div className="flex items-center justify-between gap-2 pl-8">
-            <span className="truncate text-xs text-muted-foreground">
-              {pr.repoName}
-            </span>
-            <span className="shrink-0 text-xs text-muted-foreground">
-              {dayjs(pr.createdAt).fromNow()}
-            </span>
-          </div>
-
-          {/* Row 3: Reviewer votes (if any) */}
-          {(pr.approvedBy.length > 0 || pr.blockedBy.length > 0) && (
-            <div className="flex items-center gap-1 pl-8">
-              {pr.approvedBy.map((r) => (
-                <AzureAvatar
-                  key={r.identity.id}
-                  user={r.identity}
-                  className="size-5 border-2 border-green-600"
-                />
-              ))}
-              {pr.blockedBy.map((r) => (
-                <AzureAvatar
-                  key={r.identity.id}
-                  user={r.identity}
-                  className="size-5 border-2 border-red-600"
-                />
-              ))}
+            {/* Row 2: Repo + Time */}
+            <div className="flex items-center justify-between gap-2 pl-8">
+              <span className="truncate text-xs text-muted-foreground">
+                {pr.repoName}
+              </span>
+              <span className="shrink-0 text-xs text-muted-foreground">
+                {dayjs(pr.createdAt).fromNow()}
+              </span>
             </div>
-          )}
-        </button>
-      ))}
+
+            {/* Row 3: Reviewer votes (if any) */}
+            {(pr.approvedBy.length > 0 || pr.blockedBy.length > 0) && (
+              <div className="flex items-center gap-1 pl-8">
+                {pr.approvedBy.map((r) => (
+                  <AzureAvatar
+                    key={r.identity.id}
+                    user={r.identity}
+                    className="size-[22px] border-2 border-green-600"
+                    overrideAvatarUrl={
+                      avatarOverrideMap[r.identity.uniqueName.toLowerCase()]
+                    }
+                  />
+                ))}
+                {pr.blockedBy.map((r) => (
+                  <AzureAvatar
+                    key={r.identity.id}
+                    user={r.identity}
+                    className="size-[22px] border-2 border-red-600"
+                    overrideAvatarUrl={
+                      avatarOverrideMap[r.identity.uniqueName.toLowerCase()]
+                    }
+                  />
+                ))}
+              </div>
+            )}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/toki-api/Cargo.toml
+++ b/toki-api/Cargo.toml
@@ -16,7 +16,7 @@ serde_with = "3.4.0"
 tokio = { version = "1.35.1", features = ["full"] }
 time = { version = "0.3.47", features = ["serde", "parsing"] }
 chrono = { version = "0.4.38", features = ["serde"] }
-axum = { version = "0.7.3", features = ["ws", "macros"] }
+axum = { version = "0.7.3", features = ["ws", "macros", "multipart"] }
 axum-extra = { version = "0.9.1", features = ["typed-header", "cookie"] }
 config = "0.14.0"
 tracing = { version = "0.1.40", features = ["attributes"] }
@@ -53,3 +53,5 @@ base64 = "0.22.1"
 strum_macros = "0.26.4"
 tower-sessions-moka-store = "0.14"
 tower-sessions-sqlx-store = { version = "0.14.2", features = ["postgres"] }
+image = { version = "0.25.9", features = ["jpeg", "png"] }
+webp = "0.3.1"

--- a/toki-api/migrations/20260214154000_add_user_avatars.sql
+++ b/toki-api/migrations/20260214154000_add_user_avatars.sql
@@ -1,0 +1,7 @@
+CREATE TABLE user_avatars (
+    user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    image BYTEA NOT NULL,
+    mime_type TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/toki-api/src/adapters/outbound/media/avatar_processor.rs
+++ b/toki-api/src/adapters/outbound/media/avatar_processor.rs
@@ -1,0 +1,30 @@
+use image::imageops::FilterType;
+
+use crate::domain::{models::AvatarImage, ports::outbound::AvatarProcessor, AvatarError};
+
+pub struct WebpAvatarProcessor;
+
+impl Default for WebpAvatarProcessor {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl AvatarProcessor for WebpAvatarProcessor {
+    fn process(
+        &self,
+        input: &[u8],
+        _content_type: Option<&str>,
+    ) -> Result<AvatarImage, AvatarError> {
+        let image = image::load_from_memory(input).map_err(|_| AvatarError::InvalidImage)?;
+
+        let resized = image.resize(512, 512, FilterType::Lanczos3);
+        let rgba = resized.to_rgba8();
+        let (width, height) = rgba.dimensions();
+
+        let encoder = webp::Encoder::from_rgba(&rgba, width, height);
+        let webp = encoder.encode(80.0);
+
+        Ok(AvatarImage::new(webp.to_vec(), "image/webp"))
+    }
+}

--- a/toki-api/src/adapters/outbound/media/mod.rs
+++ b/toki-api/src/adapters/outbound/media/mod.rs
@@ -1,0 +1,3 @@
+mod avatar_processor;
+
+pub use avatar_processor::WebpAvatarProcessor;

--- a/toki-api/src/adapters/outbound/mod.rs
+++ b/toki-api/src/adapters/outbound/mod.rs
@@ -1,2 +1,3 @@
+pub mod media;
 pub mod milltime;
 pub mod postgres;

--- a/toki-api/src/adapters/outbound/postgres/avatar.rs
+++ b/toki-api/src/adapters/outbound/postgres/avatar.rs
@@ -1,0 +1,131 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+
+use crate::domain::{
+    models::{AvatarIdentityRecord, AvatarImage, UserId},
+    ports::outbound::AvatarRepository,
+    AvatarError,
+};
+
+pub struct PostgresAvatarRepository {
+    pool: PgPool,
+}
+
+impl PostgresAvatarRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl AvatarRepository for PostgresAvatarRepository {
+    async fn get_avatar(&self, user_id: &UserId) -> Result<Option<AvatarImage>, AvatarError> {
+        let row = sqlx::query!(
+            r#"
+            SELECT image, mime_type
+            FROM user_avatars
+            WHERE user_id = $1
+            "#,
+            user_id.as_i32(),
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|err| AvatarError::Storage(err.to_string()))?;
+
+        Ok(row.map(|row| AvatarImage::new(row.image, row.mime_type)))
+    }
+
+    async fn set_avatar(&self, user_id: &UserId, image: &AvatarImage) -> Result<(), AvatarError> {
+        sqlx::query!(
+            r#"
+            INSERT INTO user_avatars (user_id, image, mime_type, updated_at)
+            VALUES ($1, $2, $3, now())
+            ON CONFLICT (user_id) DO UPDATE
+            SET image = EXCLUDED.image,
+                mime_type = EXCLUDED.mime_type,
+                updated_at = now()
+            "#,
+            user_id.as_i32(),
+            &image.bytes,
+            &image.mime_type,
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|err| AvatarError::Storage(err.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn delete_avatar(&self, user_id: &UserId) -> Result<(), AvatarError> {
+        sqlx::query!(
+            r#"
+            DELETE FROM user_avatars
+            WHERE user_id = $1
+            "#,
+            user_id.as_i32(),
+        )
+        .execute(&self.pool)
+        .await
+        .map_err(|err| AvatarError::Storage(err.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn avatar_updated_at(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Option<time::OffsetDateTime>, AvatarError> {
+        let updated_at = sqlx::query_scalar!(
+            r#"
+            SELECT updated_at
+            FROM user_avatars
+            WHERE user_id = $1
+            "#,
+            user_id.as_i32(),
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|err| AvatarError::Storage(err.to_string()))?;
+
+        Ok(updated_at)
+    }
+
+    async fn users_with_avatars_by_email(
+        &self,
+        emails: &[String],
+    ) -> Result<Vec<AvatarIdentityRecord>, AvatarError> {
+        if emails.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let normalized_emails = emails
+            .iter()
+            .map(|email| email.to_lowercase())
+            .collect::<Vec<_>>();
+
+        let rows = sqlx::query!(
+            r#"
+            SELECT
+                users.id as "id!",
+                lower(users.email) as "email!",
+                user_avatars.updated_at as "updated_at!"
+            FROM users
+            INNER JOIN user_avatars ON user_avatars.user_id = users.id
+            WHERE lower(users.email) = ANY($1)
+            "#,
+            &normalized_emails,
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|err| AvatarError::Storage(err.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| AvatarIdentityRecord {
+                user_id: UserId::new(row.id),
+                email: row.email,
+                updated_at: row.updated_at,
+            })
+            .collect())
+    }
+}

--- a/toki-api/src/adapters/outbound/postgres/mod.rs
+++ b/toki-api/src/adapters/outbound/postgres/mod.rs
@@ -1,3 +1,5 @@
+mod avatar;
 mod timer_history;
 
+pub use avatar::PostgresAvatarRepository;
 pub use timer_history::PostgresTimerHistoryAdapter;

--- a/toki-api/src/app_state.rs
+++ b/toki-api/src/app_state.rs
@@ -17,8 +17,8 @@ use web_push::{IsahcWebPushClient, WebPushClient, WebPushMessage};
 use crate::{
     adapters::inbound::http::TimeTrackingServiceFactory,
     domain::{
-        CachedIdentities, NotificationHandler, PullRequest, RepoConfig, RepoDiffer,
-        RepoDifferMessage, RepoKey,
+        ports::inbound::AvatarService, CachedIdentities, NotificationHandler, PullRequest,
+        RepoConfig, RepoDiffer, RepoDifferMessage, RepoKey,
     },
     repositories::{
         NotificationRepositoryImpl, PushSubscriptionRepositoryImpl, RepoRepositoryImpl,
@@ -57,6 +57,7 @@ pub struct AppState {
     pub push_subscriptions_repo: Arc<PushSubscriptionRepositoryImpl>,
     pub notification_repo: Arc<NotificationRepositoryImpl>,
     pub time_tracking_factory: Arc<dyn TimeTrackingServiceFactory>,
+    pub avatar_service: Arc<dyn AvatarService>,
     repo_clients: Arc<RwLock<HashMap<RepoKey, RepoClient>>>,
     differs: Arc<RwLock<HashMap<RepoKey, Arc<RepoDiffer>>>>,
     differ_txs: Arc<Mutex<HashMap<RepoKey, Sender<RepoDifferMessage>>>>,
@@ -72,6 +73,7 @@ impl AppState {
         db_pool: PgPool,
         repo_configs: Vec<RepoConfig>,
         time_tracking_factory: Arc<dyn TimeTrackingServiceFactory>,
+        avatar_service: Arc<dyn AvatarService>,
     ) -> Self {
         let client_futures = repo_configs
             .into_iter()
@@ -134,6 +136,7 @@ impl AppState {
             push_subscriptions_repo: Arc::new(PushSubscriptionRepositoryImpl::new(db_pool.clone())),
             notification_repo: Arc::new(NotificationRepositoryImpl::new(db_pool.clone())),
             time_tracking_factory,
+            avatar_service,
             repo_clients: Arc::new(RwLock::new(clients)),
             differ_txs: Arc::new(Mutex::new(differ_txs)),
             differs: Arc::new(RwLock::new(differs)),

--- a/toki-api/src/domain/error.rs
+++ b/toki-api/src/domain/error.rs
@@ -28,3 +28,18 @@ impl TimeTrackingError {
         Self::Unknown(msg.into())
     }
 }
+
+/// Errors that can occur during avatar operations.
+#[derive(Debug, Error)]
+pub enum AvatarError {
+    #[error("avatar not found")]
+    NotFound,
+    #[error("invalid image payload")]
+    InvalidImage,
+    #[error("avatar payload exceeds limit")]
+    PayloadTooLarge,
+    #[error("unsupported media type")]
+    UnsupportedMediaType,
+    #[error("avatar storage error: {0}")]
+    Storage(String),
+}

--- a/toki-api/src/domain/models/avatar.rs
+++ b/toki-api/src/domain/models/avatar.rs
@@ -1,0 +1,42 @@
+use serde::Serialize;
+use time::OffsetDateTime;
+
+use super::UserId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AvatarImage {
+    pub bytes: Vec<u8>,
+    pub mime_type: String,
+}
+
+impl AvatarImage {
+    pub fn new(bytes: Vec<u8>, mime_type: impl Into<String>) -> Self {
+        Self {
+            bytes,
+            mime_type: mime_type.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AvatarIdentityRecord {
+    pub user_id: UserId,
+    pub email: String,
+    pub updated_at: OffsetDateTime,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AvatarOverride {
+    pub email: String,
+    pub avatar_url: String,
+}
+
+impl AvatarOverride {
+    pub fn new(email: impl Into<String>, avatar_url: impl Into<String>) -> Self {
+        Self {
+            email: email.into(),
+            avatar_url: avatar_url.into(),
+        }
+    }
+}

--- a/toki-api/src/domain/models/mod.rs
+++ b/toki-api/src/domain/models/mod.rs
@@ -1,7 +1,9 @@
+mod avatar;
 mod ids;
 mod project;
 mod timer;
 
+pub use avatar::*;
 pub use ids::*;
 pub use project::*;
 pub use timer::*;

--- a/toki-api/src/domain/ports/inbound/avatar.rs
+++ b/toki-api/src/domain/ports/inbound/avatar.rs
@@ -1,0 +1,27 @@
+use async_trait::async_trait;
+
+use crate::domain::{
+    models::{AvatarImage, AvatarOverride, UserId},
+    AvatarError,
+};
+
+#[async_trait]
+pub trait AvatarService: Send + Sync + 'static {
+    async fn get_avatar(&self, user_id: &UserId) -> Result<Option<AvatarImage>, AvatarError>;
+
+    async fn upload_avatar(
+        &self,
+        user_id: &UserId,
+        image: Vec<u8>,
+        content_type: Option<String>,
+    ) -> Result<(), AvatarError>;
+
+    async fn delete_avatar(&self, user_id: &UserId) -> Result<(), AvatarError>;
+
+    async fn get_avatar_url(&self, user_id: &UserId) -> Result<Option<String>, AvatarError>;
+
+    async fn resolve_overrides(
+        &self,
+        emails: &[String],
+    ) -> Result<Vec<AvatarOverride>, AvatarError>;
+}

--- a/toki-api/src/domain/ports/inbound/mod.rs
+++ b/toki-api/src/domain/ports/inbound/mod.rs
@@ -1,3 +1,5 @@
+mod avatar;
 mod time_tracking;
 
+pub use avatar::*;
 pub use time_tracking::*;

--- a/toki-api/src/domain/ports/outbound/avatar.rs
+++ b/toki-api/src/domain/ports/outbound/avatar.rs
@@ -1,0 +1,26 @@
+use async_trait::async_trait;
+use time::OffsetDateTime;
+
+use crate::domain::{
+    models::{AvatarIdentityRecord, AvatarImage, UserId},
+    AvatarError,
+};
+
+#[async_trait]
+pub trait AvatarRepository: Send + Sync + 'static {
+    async fn get_avatar(&self, user_id: &UserId) -> Result<Option<AvatarImage>, AvatarError>;
+
+    async fn set_avatar(&self, user_id: &UserId, image: &AvatarImage) -> Result<(), AvatarError>;
+
+    async fn delete_avatar(&self, user_id: &UserId) -> Result<(), AvatarError>;
+
+    async fn avatar_updated_at(
+        &self,
+        user_id: &UserId,
+    ) -> Result<Option<OffsetDateTime>, AvatarError>;
+
+    async fn users_with_avatars_by_email(
+        &self,
+        emails: &[String],
+    ) -> Result<Vec<AvatarIdentityRecord>, AvatarError>;
+}

--- a/toki-api/src/domain/ports/outbound/avatar_processing.rs
+++ b/toki-api/src/domain/ports/outbound/avatar_processing.rs
@@ -1,0 +1,6 @@
+use crate::domain::{models::AvatarImage, AvatarError};
+
+pub trait AvatarProcessor: Send + Sync + 'static {
+    fn process(&self, input: &[u8], content_type: Option<&str>)
+        -> Result<AvatarImage, AvatarError>;
+}

--- a/toki-api/src/domain/ports/outbound/mod.rs
+++ b/toki-api/src/domain/ports/outbound/mod.rs
@@ -1,5 +1,9 @@
+mod avatar;
+mod avatar_processing;
 mod time_tracking;
 mod timer_history;
 
+pub use avatar::*;
+pub use avatar_processing::*;
 pub use time_tracking::*;
 pub use timer_history::*;

--- a/toki-api/src/domain/services/avatar.rs
+++ b/toki-api/src/domain/services/avatar.rs
@@ -1,0 +1,133 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+
+use crate::domain::{
+    models::{AvatarImage, AvatarOverride, UserId},
+    ports::{
+        inbound::AvatarService,
+        outbound::{AvatarProcessor, AvatarRepository},
+    },
+    AvatarError,
+};
+
+const MAX_AVATAR_SIZE: usize = 5 * 1024 * 1024;
+
+pub struct AvatarServiceImpl<R, P> {
+    repository: Arc<R>,
+    processor: Arc<P>,
+    api_url: String,
+}
+
+impl<R, P> AvatarServiceImpl<R, P> {
+    pub fn new(repository: Arc<R>, processor: Arc<P>, api_url: impl Into<String>) -> Self {
+        Self {
+            repository,
+            processor,
+            api_url: api_url.into(),
+        }
+    }
+
+    fn build_avatar_url(&self, user_id: &UserId, updated_at: time::OffsetDateTime) -> String {
+        let base_url = self.api_url.trim_end_matches('/');
+        let fingerprint = updated_at.unix_timestamp_nanos() / 1_000_000;
+        format!(
+            "{base_url}/users/{}/avatar?v={fingerprint}",
+            user_id.as_i32()
+        )
+    }
+}
+
+#[async_trait]
+impl<R: AvatarRepository, P: AvatarProcessor> AvatarService for AvatarServiceImpl<R, P> {
+    async fn get_avatar(&self, user_id: &UserId) -> Result<Option<AvatarImage>, AvatarError> {
+        self.repository.get_avatar(user_id).await
+    }
+
+    async fn upload_avatar(
+        &self,
+        user_id: &UserId,
+        image: Vec<u8>,
+        content_type: Option<String>,
+    ) -> Result<(), AvatarError> {
+        if image.len() > MAX_AVATAR_SIZE {
+            return Err(AvatarError::PayloadTooLarge);
+        }
+
+        if let Some(content_type) = content_type.as_deref() {
+            if !content_type.starts_with("image/") {
+                return Err(AvatarError::UnsupportedMediaType);
+            }
+        }
+
+        let processor = Arc::clone(&self.processor);
+        let processed = tokio::task::spawn_blocking(move || {
+            processor.process(&image, content_type.as_deref())
+        })
+        .await
+        .map_err(|err| AvatarError::Storage(format!("avatar processing task failed: {err}")))??;
+
+        self.repository.set_avatar(user_id, &processed).await
+    }
+
+    async fn delete_avatar(&self, user_id: &UserId) -> Result<(), AvatarError> {
+        self.repository.delete_avatar(user_id).await
+    }
+
+    async fn get_avatar_url(&self, user_id: &UserId) -> Result<Option<String>, AvatarError> {
+        let updated_at = self.repository.avatar_updated_at(user_id).await?;
+
+        Ok(updated_at.map(|updated_at| self.build_avatar_url(user_id, updated_at)))
+    }
+
+    async fn resolve_overrides(
+        &self,
+        emails: &[String],
+    ) -> Result<Vec<AvatarOverride>, AvatarError> {
+        if emails.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let unique_emails = emails
+            .iter()
+            .map(|email| email.to_lowercase())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+
+        let records = self
+            .repository
+            .users_with_avatars_by_email(&unique_emails)
+            .await?;
+
+        let lookup = records
+            .into_iter()
+            .map(|record| {
+                (
+                    record.email,
+                    self.build_avatar_url(&record.user_id, record.updated_at),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+
+        let mut overrides = Vec::new();
+        let mut seen = HashSet::new();
+
+        for email in emails {
+            let normalized = email.to_lowercase();
+            if seen.contains(&normalized) {
+                continue;
+            }
+
+            if let Some(url) = lookup.get(&normalized) {
+                overrides.push(AvatarOverride::new(normalized.clone(), url.clone()));
+                seen.insert(normalized);
+            }
+        }
+
+        Ok(overrides)
+    }
+}

--- a/toki-api/src/domain/services/mod.rs
+++ b/toki-api/src/domain/services/mod.rs
@@ -1,3 +1,5 @@
+mod avatar;
 mod time_tracking;
 
+pub use avatar::AvatarServiceImpl;
 pub use time_tracking::TimeTrackingServiceImpl;

--- a/toki-api/src/routes/mod.rs
+++ b/toki-api/src/routes/mod.rs
@@ -1,8 +1,9 @@
 pub(crate) mod differs;
 pub(crate) mod error;
-pub(crate) mod time_tracking;
 pub(crate) mod notifications;
 pub(crate) mod pull_requests;
 pub(crate) mod repositories;
+pub(crate) mod time_tracking;
+pub(crate) mod users;
 
 pub(crate) use error::ApiError;

--- a/toki-api/src/routes/users.rs
+++ b/toki-api/src/routes/users.rs
@@ -1,0 +1,135 @@
+use axum::{
+    body::Body,
+    extract::{DefaultBodyLimit, Multipart, Path, State},
+    http::{header, HeaderValue, StatusCode},
+    response::Response,
+    routing::get,
+    Router,
+};
+
+use crate::{
+    app_state::AppState,
+    auth::AuthSession,
+    domain::{models::UserId, AvatarError},
+    routes::ApiError,
+};
+
+const DEFAULT_AVATAR_MIME: &str = "image/webp";
+const AVATAR_CACHE_CONTROL: &str = "private, max-age=3600";
+// Allow multipart overhead while keeping the actual avatar payload policy at 5 MiB.
+const AVATAR_UPLOAD_BODY_LIMIT: usize = 6 * 1024 * 1024;
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/me/avatar",
+            get(my_avatar)
+                .post(upload_my_avatar)
+                .delete(delete_my_avatar),
+        )
+        .route_layer(DefaultBodyLimit::max(AVATAR_UPLOAD_BODY_LIMIT))
+        .route("/:user_id/avatar", get(user_avatar))
+}
+
+async fn my_avatar(
+    auth_session: AuthSession,
+    State(app_state): State<AppState>,
+) -> Result<Response, ApiError> {
+    let user = auth_session
+        .user
+        .as_ref()
+        .ok_or_else(|| ApiError::unauthorized("user not found"))?;
+
+    avatar_response(&app_state, UserId::from(user.id)).await
+}
+
+async fn user_avatar(
+    Path(user_id): Path<i32>,
+    State(app_state): State<AppState>,
+) -> Result<Response, ApiError> {
+    avatar_response(&app_state, UserId::from(user_id)).await
+}
+
+async fn upload_my_avatar(
+    auth_session: AuthSession,
+    State(app_state): State<AppState>,
+    mut multipart: Multipart,
+) -> Result<StatusCode, ApiError> {
+    let user = auth_session
+        .user
+        .as_ref()
+        .ok_or_else(|| ApiError::unauthorized("user not found"))?;
+
+    let (image, content_type) = extract_image_from_multipart(&mut multipart).await?;
+
+    app_state
+        .avatar_service
+        .upload_avatar(&UserId::from(user.id), image, content_type)
+        .await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn delete_my_avatar(
+    auth_session: AuthSession,
+    State(app_state): State<AppState>,
+) -> Result<StatusCode, ApiError> {
+    let user = auth_session
+        .user
+        .as_ref()
+        .ok_or_else(|| ApiError::unauthorized("user not found"))?;
+
+    app_state
+        .avatar_service
+        .delete_avatar(&UserId::from(user.id))
+        .await?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn avatar_response(app_state: &AppState, user_id: UserId) -> Result<Response, ApiError> {
+    let avatar = app_state
+        .avatar_service
+        .get_avatar(&user_id)
+        .await?
+        .ok_or(AvatarError::NotFound)?;
+
+    let mut response = Response::new(Body::from(avatar.bytes));
+    let headers = response.headers_mut();
+
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_str(&avatar.mime_type)
+            .unwrap_or_else(|_| HeaderValue::from_static(DEFAULT_AVATAR_MIME)),
+    );
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static(AVATAR_CACHE_CONTROL),
+    );
+
+    Ok(response)
+}
+
+async fn extract_image_from_multipart(
+    multipart: &mut Multipart,
+) -> Result<(Vec<u8>, Option<String>), ApiError> {
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|_| ApiError::bad_request("failed to parse multipart field"))?
+    {
+        if field.name() != Some("avatar") {
+            continue;
+        }
+
+        let content_type = field.content_type().map(str::to_string);
+        let bytes = field
+            .bytes()
+            .await
+            .map_err(|_| ApiError::bad_request("failed to read avatar payload"))?;
+
+        return Ok((bytes.to_vec(), content_type));
+    }
+
+    Err(ApiError::bad_request("missing avatar file field"))
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new file-upload endpoints and stores binary image data in the database, plus touches auth `me` responses and PR list shaping; failures could impact request handling, storage growth, and avatar rendering across the UI.
> 
> **Overview**
> Adds end-to-end **custom avatar support**: users can upload/delete a profile image (stored in Postgres and served via new `GET/POST/DELETE /users/me/avatar` plus `GET /users/:id/avatar`), with server-side validation (size/type), background WebP processing/resizing, cacheable fingerprinted URLs, and error-to-HTTP mapping.
> 
> Updates the PR list API to include `avatarOverrides` for all PR participants so the UI can substitute custom avatars across PR lists/details, and adds a new avatar settings dialog in the sidebar with file validation/preview plus a persisted Pokémon fallback toggle and client-side source fallback handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18bb2a2f8ea2639bba2a630f3a40869bf4585b98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Full-stack feature adding custom avatar support. Users can upload, preview, and delete custom profile images via a new dialog in the sidebar navigation. Uploaded images are resized to 512x512 and encoded to WebP server-side, then stored as `BYTEA` in a new `user_avatars` PostgreSQL table.

The backend follows the project's hexagonal architecture pattern with clean separation into domain models, inbound/outbound ports, service implementation, and adapters. The PR list endpoint is enriched with `avatarOverrides` — a batch-resolved mapping of participant emails to custom avatar URLs — so custom avatars appear throughout the PR views without extra client-side fetches.

On the frontend, a new `useAvatarSourceWithFallback` hook provides cascading image source fallback (custom avatar → Azure AD picture → deterministic Pokemon sprite → letter initial). Avatar color theming uses WCAG-compliant contrast ratio calculations for accessibility across light/dark modes.

- Backend: new `/users` route with avatar CRUD endpoints, `AvatarService` trait + implementation, `PostgresAvatarRepository`, `WebpAvatarProcessor` running in `spawn_blocking`
- Frontend: avatar upload dialog with preview, `useAvatarSourceWithFallback` hook, Pokemon fallback toggle persisted in localStorage, avatar overrides threaded through all PR views
- Infrastructure: new `user_avatars` migration, `.sqlx` offline query metadata, `image` + `webp` crate dependencies

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — well-structured feature with clean architecture, proper validation, and no critical issues.
- The implementation follows the project's established hexagonal architecture pattern consistently. Input validation covers file size (5 MiB), content type, and image format. CPU-intensive image processing runs in `spawn_blocking`. Cache invalidation correctly targets both `/me` and pull request queries. The `ON CONFLICT` upsert properly preserves `created_at`. Frontend avatar fallback cascading is robust with memoized sources. All previously flagged review concerns have been addressed in this revision.
- No files require special attention. The `useAvatarSourceWithFallback` hook relies on callers memoizing the `sources` array, which all current callers do correctly.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| toki-api/src/domain/services/avatar.rs | Core avatar service with upload, delete, retrieval, and batch override resolution. Properly uses `spawn_blocking` for image processing, validates size/content-type, and builds cache-busted URLs via `updated_at` fingerprinting. |
| toki-api/src/routes/users.rs | New HTTP route handlers for avatar CRUD: multipart upload, GET by user ID, and DELETE. Body limit correctly scoped to upload route. Auth enforced globally. |
| toki-api/src/routes/pull_requests.rs | Extended `ListPullRequest` with `avatar_overrides` field. Enriches PR responses by batch-resolving participant emails to custom avatar URLs via a single DB query per request. |
| toki-api/src/adapters/outbound/postgres/avatar.rs | PostgreSQL repository for avatar CRUD. Uses UPSERT with `ON CONFLICT` correctly preserving `created_at`. Batch email lookup via `ANY($1)` for efficient override resolution. |
| toki-api/src/adapters/outbound/media/avatar_processor.rs | Resizes uploaded images to 512x512 using Lanczos3 and encodes to WebP at quality 80. Runs in `spawn_blocking` context. |
| toki-api/src/auth/router.rs | Extended `/me` endpoint to return `MeResponse` with flattened user fields plus `avatarUrl`. Uses `#[serde(flatten)]` correctly with camelCase rename. |
| toki-api/migrations/20260214154000_add_user_avatars.sql | Creates `user_avatars` table with `BYTEA` storage, `CASCADE` delete on user removal, and separate `created_at`/`updated_at` timestamps. |
| app/src/components/azure-avatar.tsx | Refactored avatar component to support custom avatar URLs, Pokemon fallback avatars with deterministic selection, and accessible color theming. Added null-safe fallback initials. |
| app/src/components/side-nav.tsx | Added avatar management dialog with file upload, preview, delete, and Pokemon fallback toggle. Uses mutation hooks with proper query invalidation. |
| app/src/hooks/useAvatarSourceWithFallback.ts | Hook for cascading avatar source fallback. Tracks failed image URLs and falls through to next source. Callers must memoize the `sources` array to avoid resetting state on every render. |
| app/src/lib/avatar.ts | Utility module for deterministic avatar generation: FNV-1a hashing for stable Pokemon ID selection, WCAG-compliant color generation with contrast ratio checks, and avatar source deduplication. |
| app/src/lib/api/mutations/user.ts | Avatar upload and delete mutations with proper cache invalidation of both `["me"]` and `pullRequestsQueries.baseKey` queries. |
| app/src/routes/_layout/prs/$prId/route.tsx | Threaded avatar override map through PR detail dialog, header, threads, and comments. Map is memoized once per dialog. |
| app/src/routes/_layout/prs/-components/columns.tsx | Added avatar overrides to Author and Votes columns with WeakMap caching to avoid redundant map construction per render cycle. |
| app/src/routes/_layout/prs/-components/pr-card-list.tsx | Added avatar override support to the mobile PR card list view. Override map built per card in the render loop. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Frontend (React)
    participant API as Axum API
    participant Svc as AvatarService
    participant Proc as WebpAvatarProcessor
    participant DB as PostgreSQL

    Note over UI,DB: Avatar Upload Flow
    UI->>API: POST /users/me/avatar (multipart)
    API->>Svc: upload_avatar(user_id, bytes, content_type)
    Svc->>Svc: Validate size ≤ 5 MiB & content type
    Svc->>Proc: spawn_blocking → process(bytes)
    Proc->>Proc: Resize 512x512 + encode WebP
    Proc-->>Svc: AvatarImage(webp_bytes, "image/webp")
    Svc->>DB: UPSERT user_avatars
    DB-->>Svc: OK
    Svc-->>API: OK
    API-->>UI: 204 No Content
    UI->>UI: Invalidate ["me"] + ["pullRequests"] queries

    Note over UI,DB: PR List with Avatar Overrides
    UI->>API: GET /pull-requests/list
    API->>Svc: resolve_overrides(participant_emails)
    Svc->>DB: SELECT users JOIN user_avatars WHERE email = ANY(emails)
    DB-->>Svc: [{user_id, email, updated_at}]
    Svc->>Svc: Build avatar URLs with cache-bust fingerprint
    Svc-->>API: Vec<AvatarOverride>
    API-->>UI: ListPullRequest[] with avatarOverrides
    UI->>UI: Render with cascading fallback (custom → Azure AD → Pokemon → letter)
```

<sub>Last reviewed commit: 18bb2a2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->