### PR TITLE
add default project setting

### DIFF
--- a/app/src/components/cmd-k.tsx
+++ b/app/src/components/cmd-k.tsx
@@ -28,6 +28,13 @@ import {
   useMilltimeIsAuthenticated,
 } from "@/hooks/useMilltimeStore";
 import { useTitleStore } from "@/hooks/useTitleStore";
+import { useAtomValue } from "jotai/react";
+import {
+  lastActivityAtom,
+  lastProjectAtom,
+  rememberLastProjectAtom,
+  buildRememberedTimerParams,
+} from "@/lib/milltime-preferences";
 
 export function CmdK() {
   const [open, setOpen] = React.useState(false);
@@ -97,6 +104,10 @@ function ActionsCommandGroup(props: { close: () => void }) {
     useMilltimeActions();
   const isAuthenticatedToMilltime = useMilltimeIsAuthenticated();
 
+  const lastProject = useAtomValue(lastProjectAtom);
+  const lastActivity = useAtomValue(lastActivityAtom);
+  const rememberLastProject = useAtomValue(rememberLastProjectAtom);
+
   // TODO: should probably handle the fetched timer and saveTimer in a centralized place
   const { data: timerResponse } = useQuery({
     ...milltimeQueries.getTimer(),
@@ -113,6 +124,11 @@ function ActionsCommandGroup(props: { close: () => void }) {
       removeSegment("timer");
       startStandaloneTimer({
         userNote: "Continuing my work...",
+        ...buildRememberedTimerParams({
+          rememberLastProject,
+          lastProject,
+          lastActivity,
+        }),
       });
     },
   });
@@ -127,13 +143,20 @@ function ActionsCommandGroup(props: { close: () => void }) {
             onSelect={() => {
               startStandaloneTimer({
                 userNote: "Doing something important...",
+                ...buildRememberedTimerParams({
+                  rememberLastProject,
+                  lastProject,
+                  lastActivity,
+                }),
               });
               props.close();
             }}
           >
             <div className="flex flex-row items-center gap-2">
               <DrumIcon className="h-1 w-1" />
-              Start empty timer
+              {rememberLastProject && lastProject
+                ? `Start timer (${lastProject.projectName}${lastActivity ? ` - ${lastActivity.activityName}` : ""})`
+                : "Start empty timer"}
             </div>
           </CommandItem>
           <CommandItem

--- a/app/src/lib/api/mutations/milltime.ts
+++ b/app/src/lib/api/mutations/milltime.ts
@@ -307,6 +307,10 @@ export type StartTimerPayload = {
 
 export type StartStandaloneTimerPayload = {
   userNote?: string;
+  projectId?: string;
+  projectName?: string;
+  activityId?: string;
+  activityName?: string;
 };
 export type SaveTimerPayload = {
   timerType: TimerType;

--- a/app/src/lib/milltime-preferences.ts
+++ b/app/src/lib/milltime-preferences.ts
@@ -1,0 +1,61 @@
+import { atomWithStorage } from "jotai/utils";
+
+export type LastProject = {
+  projectId: string;
+  projectName: string;
+} | null;
+
+export type LastActivity = {
+  activityId: string;
+  activityName: string;
+} | null;
+
+export const lastProjectAtom = atomWithStorage<LastProject>(
+  "milltime-lastProject",
+  null,
+);
+
+export const lastActivityAtom = atomWithStorage<LastActivity>(
+  "milltime-lastActivity",
+  null,
+);
+
+export const rememberLastProjectAtom = atomWithStorage(
+  "milltime-rememberLastProject",
+  false,
+);
+
+/**
+ * Builds the project/activity params for starting a timer based on remembered preferences.
+ */
+export function buildRememberedTimerParams(opts: {
+  rememberLastProject: boolean;
+  lastProject: LastProject;
+  lastActivity: LastActivity;
+}): {
+  projectId?: string;
+  projectName?: string;
+  activityId?: string;
+  activityName?: string;
+} {
+  const { rememberLastProject, lastProject, lastActivity } = opts;
+
+  if (!rememberLastProject) {
+    return {};
+  }
+
+  return {
+    ...(lastProject
+      ? {
+          projectId: lastProject.projectId,
+          projectName: lastProject.projectName,
+        }
+      : {}),
+    ...(lastActivity
+      ? {
+          activityId: lastActivity.activityId,
+          activityName: lastActivity.activityName,
+        }
+      : {}),
+  };
+}

--- a/app/src/routes/_layout/milltime/-components/milltime-settings.tsx
+++ b/app/src/routes/_layout/milltime/-components/milltime-settings.tsx
@@ -1,0 +1,67 @@
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { Settings2Icon } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+export const MilltimeSettings = (props: {
+  rememberLastProject: boolean;
+  setRememberLastProject: (value: boolean) => void;
+}) => {
+  return (
+    <Popover>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <PopoverTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-muted-foreground hover:text-foreground"
+              >
+                <Settings2Icon className="h-4 w-4" />
+                <span className="sr-only">Settings</span>
+              </Button>
+            </PopoverTrigger>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Milltime settings</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <PopoverContent
+        align="end"
+        className="w-72 border-zinc-600 bg-gradient-to-br from-zinc-800 to-zinc-900 shadow-lg"
+      >
+        <div className="space-y-4">
+          <h4 className="text-sm font-medium leading-none">Preferences</h4>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="remember-project" className="text-sm font-normal">
+                Remember project
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Auto-fill last used project and activity for new timers.
+              </p>
+            </div>
+            <Switch
+              id="remember-project"
+              checked={props.rememberLastProject}
+              onCheckedChange={props.setRememberLastProject}
+            />
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/app/src/routes/_layout/milltime/index.tsx
+++ b/app/src/routes/_layout/milltime/index.tsx
@@ -19,8 +19,15 @@ import { milltimeQueries } from "@/lib/api/queries/milltime";
 import { startOfWeek, endOfWeek, format } from "date-fns";
 import React from "react";
 import { atomWithStorage } from "jotai/utils";
-import { useAtom } from "jotai/react";
+import { useAtom, useAtomValue } from "jotai/react";
 import { MergeEntriesSwitch } from "./-components/merge-entries-switch";
+import { MilltimeSettings } from "./-components/milltime-settings";
+import {
+  buildRememberedTimerParams,
+  lastActivityAtom,
+  lastProjectAtom,
+  rememberLastProjectAtom,
+} from "@/lib/milltime-preferences";
 import { TimeStats } from "./-components/time-stats";
 import { milltimeMutations } from "@/lib/api/mutations/milltime";
 import {
@@ -68,6 +75,11 @@ function MilltimeComponent() {
     to: format(endOfWeek(new Date(), { weekStartsOn: 1 }), "yyyy-MM-dd"),
   });
   const [mergeSameDay, setMergeSameDay] = useAtom(mergeSameDayPersistedAtom);
+  const [rememberLastProject, setRememberLastProject] = useAtom(
+    rememberLastProjectAtom,
+  );
+  const lastProject = useAtomValue(lastProjectAtom);
+  const lastActivity = useAtomValue(lastActivityAtom);
   const [search, setSearch] = React.useState("");
 
   const { data: timeEntries } = useQuery({
@@ -122,12 +134,19 @@ function MilltimeComponent() {
                     onClick={() =>
                       startStandaloneTimer({
                         userNote: "Try Ctrl+K to start a timer next time",
+                        ...buildRememberedTimerParams({
+                          rememberLastProject,
+                          lastProject,
+                          lastActivity,
+                        }),
                       })
                     }
                     className="w-full md:w-auto"
                   >
                     <TimerIcon className="mr-2 h-4 w-4" />
-                    Start New Timer
+                    {rememberLastProject && lastProject
+                      ? `Start Timer (${lastProject.projectName}${lastActivity ? ` - ${lastActivity.activityName}` : ""})`
+                      : "Start New Timer"}
                   </Button>
                 )}
                 <Button
@@ -153,6 +172,10 @@ function MilltimeComponent() {
                       setMergeSameDay={setMergeSameDay}
                     />
                     <SearchBar search={search} setSearch={setSearch} />
+                    <MilltimeSettings
+                      rememberLastProject={rememberLastProject}
+                      setRememberLastProject={setRememberLastProject}
+                    />
                   </div>
                 </div>
                 {timeEntries?.length ? (

--- a/toki-api/src/routes/milltime/timer.rs
+++ b/toki-api/src/routes/milltime/timer.rs
@@ -182,6 +182,10 @@ pub async fn start_timer(
 #[serde(rename_all = "camelCase")]
 pub struct StartStandaloneTimerPayload {
     user_note: Option<String>,
+    project_id: Option<String>,
+    project_name: Option<String>,
+    activity_id: Option<String>,
+    activity_name: Option<String>,
 }
 
 #[instrument(name = "start_standalone_timer", skip(app_state, auth_session))]
@@ -204,10 +208,10 @@ pub async fn start_standalone_timer(
     let new_timer = repositories::NewDatabaseTimer {
         user_id: user.id,
         start_time: time::OffsetDateTime::now_utc(),
-        project_id: None,
-        project_name: None,
-        activity_id: None,
-        activity_name: None,
+        project_id: body.project_id,
+        project_name: body.project_name,
+        activity_id: body.activity_id,
+        activity_name: body.activity_name,
         note: body.user_note.clone().unwrap_or_default(),
         timer_type: TimerType::Standalone,
     };


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added a "Remember project" preference that auto-fills the last used project and activity when creating new timers. The feature uses Jotai atoms with localStorage persistence to remember the user's last project/activity selection across sessions.

**Key changes:**
- Created new preference storage using `atomWithStorage` for project, activity, and toggle state
- Extended backend API to accept optional `projectId`, `projectName`, `activityId`, `activityName` fields in standalone timer creation
- Integrated preference into timer creation flows: Cmd+K command palette, start timer buttons, and auto-restart on save
- Added settings popover to Milltime page for toggling the feature
- Updated button labels to show the remembered project name when enabled

**Minor issue:**
- `remember-project-switch.tsx` appears to be unused duplicate code - consider removing it

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation is well-structured with proper frontend-backend coordination. All changes are additive (optional fields) and won't break existing functionality. The feature uses established patterns (Jotai for state, optional payload fields) and localStorage persistence is appropriate for user preferences. The only minor issue is an unused component file which doesn't affect functionality.
- No files require special attention - the unused `remember-project-switch.tsx` can be removed in a follow-up

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| app/src/lib/milltime-preferences.ts | New file adding Jotai atoms for persisting project/activity preferences in localStorage |
| toki-api/src/routes/milltime/timer.rs | Extended API payload to accept optional project/activity fields for standalone timers |
| app/src/routes/_layout/milltime/-components/remember-project-switch.tsx | Unused component with duplicate functionality of milltime-settings.tsx |
| app/src/components/cmd-k.tsx | Updated command palette to use remembered project/activity when starting timers |
| app/src/components/floating-milltime-timer.tsx | Saves project/activity on timer completion and uses it for auto-restart |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant UI as UI Components
    participant Store as Jotai Atoms
    participant API as Toki API
    participant DB as PostgreSQL

    Note over User,DB: Feature: Remember Last Project for Timers

    User->>UI: Toggle "Remember project" setting
    UI->>Store: setRememberLastProject(true)
    Store->>Store: Save to localStorage

    User->>UI: Start timer with project/activity
    UI->>API: POST /milltime/timer (with project data)
    API->>DB: Create timer with project/activity
    DB-->>API: Timer created
    API-->>UI: Success

    User->>UI: Save/Complete timer
    UI->>Store: setLastProject({projectId, projectName})
    UI->>Store: setLastActivity({activityId, activityName})
    Store->>Store: Persist to localStorage

    User->>UI: Start new timer (Cmd+K or button)
    UI->>Store: Read lastProject, lastActivity, rememberLastProject
    Store-->>UI: Return saved values
    alt Remember project enabled
        UI->>API: POST /milltime/start-standalone-timer (with saved project/activity)
        API->>DB: Create timer pre-filled with project/activity
    else Remember project disabled
        UI->>API: POST /milltime/start-standalone-timer (without project/activity)
        API->>DB: Create empty timer
    end
    DB-->>API: Timer created
    API-->>UI: Success

```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->