### PR TITLE
use Moka for caching available projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4934,6 +4934,7 @@ dependencies = [
  "image",
  "itertools 0.13.0",
  "milltime",
+ "moka",
  "oauth2",
  "reqwest 0.12.28",
  "serde",

--- a/toki-api/Cargo.toml
+++ b/toki-api/Cargo.toml
@@ -57,3 +57,4 @@ tower-sessions-moka-store = "0.14"
 tower-sessions-sqlx-store = { version = "0.14.2", features = ["postgres"] }
 image = { version = "0.25.9", features = ["jpeg", "png"] }
 webp = "0.3.1"
+moka = { version = "0.12", features = ["sync"] }


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996d27355a8832b81dbbadb02d67025)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced manual cache implementation with moka library for `AVAILABLE_PROJECTS_CACHE`. This change eliminates ~40 lines of custom cache management code (manual TTL checking, eviction logic, capacity management) in favor of moka's built-in features.

**Key changes:**
- Removed custom `CachedAvailableProjects` struct and `RwLock<HashMap>` cache
- Replaced with `moka::sync::Cache` with 30-second TTL and 2048-entry capacity
- Simplified `get_available_projects_cached` function from ~30 lines to ~8 lines
- Added two unit tests verifying cache TTL behavior
- Removed unused `Instant` import and `AVAILABLE_PROJECTS_CACHE_EVICT_AFTER` constant
- Fixed formatting (removed blank line at line 370)

<h3>Confidence Score: 5/5</h3>

- Safe to merge - replaces complex manual cache with battle-tested library
- Code quality improvement with no logical issues. The moka library is mature and already used in the project (via tower-sessions-moka-store). The refactor simplifies cache logic, maintains the same functional behavior, and adds test coverage. No breaking changes to the API surface.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| toki-api/Cargo.toml | Added moka crate with sync features |
| toki-api/src/routes/work_items/mod.rs | Replaced manual cache implementation with moka library, simplified cache logic by ~40 lines, added unit tests |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[get_available_projects_cached called] --> B{Check moka cache for user_id}
    B -->|Cache hit| C[Return cached Vec WorkItemProject]
    B -->|Cache miss| D[Fetch from work_item_factory]
    D --> E[Insert into cache with 30s TTL]
    E --> F[Return Vec WorkItemProject]
    
    G[Background: moka handles] -.->|Auto-evict after 30s| H[TTL expiration]
    G -.->|Auto-evict when full| I[Capacity management max 2048]
```

<sub>Last reviewed commit: b63f264</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->