### PR TITLE
fix: timeouts for certain projects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "azure_core 0.25.0",
  "azure_devops_rust_api",
  "dotenvy",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -586,6 +587,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1993,6 +2000,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -2559,6 +2567,12 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -3496,6 +3510,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.36",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3778,6 +3847,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3785,6 +3856,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http 0.6.8",
@@ -3794,6 +3866,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3909,6 +3982,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3971,6 +4050,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -5770,6 +5850,16 @@ name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/app/src/lib/api/queries/workItems.ts
+++ b/app/src/lib/api/queries/workItems.ts
@@ -118,10 +118,13 @@ export const workItemsQueries = {
   }) =>
     queryOptions({
       queryKey: [...workItemsQueries.baseKey, "board", params],
-      refetchInterval: 60 * 1000,
+      refetchInterval: 60_000,
+      retry: 1,
+      retryDelay: 1_000,
       queryFn: async () =>
         api
           .get("work-items/board", {
+            timeout: 45_000,
             searchParams: Object.fromEntries(
               Object.entries(params).filter(([, v]) => v !== undefined),
             ),

--- a/app/src/routes/_layout/board/-components/board-view.tsx
+++ b/app/src/routes/_layout/board/-components/board-view.tsx
@@ -64,7 +64,11 @@ export function BoardView({
   iterationPath?: string;
   team?: string;
 }) {
-  const { data: board } = useQuery({
+  const {
+    data: board,
+    isError: isBoardError,
+    refetch: refetchBoard,
+  } = useQuery({
     ...queries.board({
       organization,
       project,
@@ -140,7 +144,8 @@ export function BoardView({
     [hiddenColumnIds],
   );
   const selectedMemberEmailSet = useMemo(
-    () => new Set(memberFilter.selectedEmails.map((email) => email.toLowerCase())),
+    () =>
+      new Set(memberFilter.selectedEmails.map((email) => email.toLowerCase())),
     [memberFilter.selectedEmails],
   );
   const boardItems = useMemo(() => board?.items ?? [], [board]);
@@ -182,7 +187,13 @@ export function BoardView({
 
       return true;
     });
-  }, [boardItems, categoryFilter, memberFilter, selectedMemberEmailSet, user.email]);
+  }, [
+    boardItems,
+    categoryFilter,
+    memberFilter,
+    selectedMemberEmailSet,
+    user.email,
+  ]);
 
   const columnsWithItems = useMemo(() => {
     const columns = [...boardColumns].sort(
@@ -221,7 +232,8 @@ export function BoardView({
     [columnsWithItems, hiddenColumnIdSet],
   );
   const allColumns = useMemo(
-    () => columnsWithItems.map((column) => ({ id: column.id, name: column.name })),
+    () =>
+      columnsWithItems.map((column) => ({ id: column.id, name: column.name })),
     [columnsWithItems],
   );
   const allColumnsRef = useRef(allColumns);
@@ -298,13 +310,7 @@ export function BoardView({
         }
       }
     },
-    [
-      iterationPath,
-      moveBoardItem,
-      organization,
-      project,
-      team,
-    ],
+    [iterationPath, moveBoardItem, organization, project, team],
   );
 
   const handleCardDragStart = useCallback(
@@ -370,6 +376,21 @@ export function BoardView({
   );
 
   if (!board) {
+    if (isBoardError) {
+      return (
+        <div className="flex h-[60vh] items-center justify-center">
+          <div className="flex max-w-xl flex-col items-center gap-3 text-center">
+            <p className="text-sm text-muted-foreground">
+              Failed to load board data. Please retry.
+            </p>
+            <Button size="sm" onClick={() => void refetchBoard()}>
+              Retry board load
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div className="flex h-[60vh] items-center justify-center">
         <p className="text-sm text-muted-foreground">Loading board...</p>
@@ -407,7 +428,10 @@ export function BoardView({
         ) : (
           <div className="flex h-full w-full gap-4 overflow-x-auto pb-2">
             {visibleColumns.map((column) => (
-              <div key={column.id} className="h-full min-h-0 min-w-[20rem] flex-1">
+              <div
+                key={column.id}
+                className="h-full min-h-0 min-w-[20rem] flex-1"
+              >
                 <BoardColumn
                   columnId={column.id}
                   title={column.name}

--- a/az-devops/Cargo.toml
+++ b/az-devops/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 azure_core = "0.25.0"
 azure_devops_rust_api = { version = "0.28.0", features = [
+    "core",
     "git",
     "pipelines",
     "wit",
@@ -16,6 +17,7 @@ azure_devops_rust_api = { version = "0.28.0", features = [
 ] }
 serde = { version = "1.0.193", features = ["derive"] }
 serde_json = "1.0.108"
+reqwest = { version = "0.12.15", default-features = false, features = ["json", "rustls-tls"] }
 thiserror = "2.0.12"
 time = { version = "0.3.47", features = ["serde", "parsing"] }
 tokio = { version = "1.35.1", features = ["full"] }

--- a/toki-api/src/domain/ports/outbound/work_item_provider.rs
+++ b/toki-api/src/domain/ports/outbound/work_item_provider.rs
@@ -26,7 +26,7 @@ pub trait WorkItemProvider: Send + Sync + 'static {
     /// - `iteration_path`: Filter by iteration/sprint path (e.g. "Project\\Sprint 5").
     ///   If `None`, uses the current iteration.
     /// - `team`: Team context for WIQL macros like `@currentIteration`.
-    ///   If `None`, defaults to the project name.
+    ///   If `None`, the adapter resolves a deterministic default team for the project.
     async fn query_work_item_ids(
         &self,
         iteration_path: Option<&str>,

--- a/toki-api/src/routes/work_items/mod.rs
+++ b/toki-api/src/routes/work_items/mod.rs
@@ -145,7 +145,17 @@ async fn get_iterations(
     Ok(Json(iterations.into_iter().map(Into::into).collect()))
 }
 
-#[instrument(name = "GET /work-items/board")]
+#[instrument(
+    name = "GET /work-items/board",
+    skip(user, app_state),
+    fields(
+        user_id = %user.id,
+        organization = %query.organization,
+        project = %query.project,
+        iteration_path = ?query.iteration_path,
+        team = ?query.team,
+    )
+)]
 async fn get_board(
     user: AuthUser,
     State(app_state): State<AppState>,


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed timeout issues for projects with large or complex team configurations by implementing multi-layered timeout handling and team fallback mechanisms.

**Key Changes:**
- Added 8-second timeout to WIQL queries in Rust backend using `tokio::time::timeout` and `reqwest` per-request timeout
- Implemented project-scope WIQL endpoint to avoid team-scoped routing issues when default teams don't exist
- Added team candidate fallback system that tries multiple team names (e.g., "{Project} Team", project name, discovered teams) with graceful degradation
- Parallelized board data fetching using `tokio::join!` to reduce overall latency
- Added 45-second client-side timeout with retry logic (max 1 retry, 1s delay) and user-friendly timeout error messages
- Added comprehensive performance timing instrumentation throughout the request pipeline

**Technical Improvements:**
- New `RepoClient` method `query_work_item_ids_wiql_project_scope()` bypasses team-scoped WIQL routes
- Team resolution now tries multiple candidates and falls back gracefully instead of failing immediately
- Board columns derived from item metadata when taskboard columns API returns empty results
- Reusable `reqwest::Client` stored in `RepoClient` struct for connection pooling

<h3>Confidence Score: 3/5</h3>

- Safe to merge with minor timeout handling gaps that could affect large responses
- The PR successfully addresses timeout issues with comprehensive client and server-side handling, team fallback logic, and performance improvements. However, response body reads (`.text()` and `.json()`) in the new WIQL endpoint are outside the timeout wrapper, which could still hang on large responses. The rest of the implementation is solid with proper error handling, parallel fetching, and graceful degradation.
- Pay close attention to `az-devops/src/repo_client.rs` - the response body reads need timeout protection

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| az-devops/src/repo_client.rs | Added timeout handling for WIQL queries (8s), new project-scope WIQL endpoint, team discovery API, and error mapping; response body reads still outside timeout wrapper |
| toki-api/src/adapters/outbound/azure_devops/mod.rs | Implemented team candidate fallback mechanism to handle team naming issues and avoid hardcoded team assumptions; improved error handling |
| toki-api/src/domain/services/work_items.rs | Parallelized board data fetching with `tokio::join!`, improved column derivation logic when taskboard unavailable, added performance timing metrics |
| app/src/lib/api/queries/workItems.ts | Added client-side 45s timeout, retry logic (max 1 retry with 1s delay), and refetch interval configuration |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as React Client
    participant API as Toki API
    participant Service as WorkItemService
    participant Adapter as AzureDevOpsAdapter
    participant RepoClient as RepoClient
    participant AzureAPI as Azure DevOps API

    Client->>API: GET /work-items/board (45s timeout)
    activate API
    
    API->>Service: get_board_data()
    activate Service
    
    Service->>Adapter: query_work_item_ids()
    activate Adapter
    
    alt Has iteration_path, no team
        Adapter->>RepoClient: query_work_item_ids_wiql_project_scope() (8s timeout)
        RepoClient->>AzureAPI: POST /wit/wiql (project-scope)
        AzureAPI-->>RepoClient: Work item IDs
        RepoClient-->>Adapter: IDs
    else Team-based query with fallback
        loop For each team candidate
            Adapter->>RepoClient: query_work_item_ids_wiql(team) (8s timeout)
            RepoClient->>AzureAPI: POST /wit/wiql (team-scope)
            alt Success
                AzureAPI-->>RepoClient: Work item IDs
                RepoClient-->>Adapter: IDs
            else Timeout or error
                AzureAPI-->>RepoClient: Error
                RepoClient-->>Adapter: Error, try next team
            end
        end
    end
    
    Adapter-->>Service: Work item IDs
    deactivate Adapter
    
    par Parallel fetching
        Service->>Adapter: get_work_items()
        Adapter->>RepoClient: get_work_items()
        RepoClient->>AzureAPI: Fetch items
        AzureAPI-->>RepoClient: Items
        RepoClient-->>Adapter: Items
        Adapter-->>Service: Items
    and
        Service->>Adapter: get_board_columns()
        Adapter->>RepoClient: get_taskboard_columns()
        RepoClient->>AzureAPI: Fetch columns
        AzureAPI-->>RepoClient: Columns
        RepoClient-->>Adapter: Columns
        Adapter-->>Service: Columns
    and
        Service->>Adapter: get_taskboard_column_assignments()
        Adapter->>RepoClient: get_taskboard_work_item_columns()
        RepoClient->>AzureAPI: Fetch assignments
        AzureAPI-->>RepoClient: Assignments
        RepoClient-->>Adapter: Assignments
        Adapter-->>Service: Assignments
    end
    
    Service->>Service: Merge data, derive columns if needed
    Service-->>API: BoardData
    deactivate Service
    
    API->>API: Enrich with avatars and PRs
    API-->>Client: BoardResponse
    deactivate API
    
    alt Timeout occurred
        Client->>Client: Show "Board loading timed out" error
        Client->>API: Retry on user action
    end
```

<sub>Last reviewed commit: 9d8f19c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->