### PR TITLE
fix(tui): filter KeyEventKind::Press to prevent double-keypress on Windows

### DIFF
--- a/toki-tui/src/main.rs
+++ b/toki-tui/src/main.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result};
 use api_client::ApiClient;
 use app::{App, TextInput};
 use crossterm::{
-    event::{self, Event, KeyCode, KeyModifiers},
+    event::{self, Event, KeyCode, KeyEventKind, KeyModifiers},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -237,6 +237,9 @@ async fn run_app(
 
         if event::poll(Duration::from_millis(100))? {
             if let Event::Key(key) = event::read()? {
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
                 // Milltime re-auth overlay intercepts all keys while it is open
                 if app.milltime_reauth.is_some() {
                     match key.code {


### PR DESCRIPTION
Small change to the keyboard event handling for the Windows-version of the TUI. It ensures that only key press events (and not key release or repeat events) are processed, preventing unintended behavior from multiple event firings.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a one-liner guard in `toki-tui/src/main.rs` to filter out non-`Press` keyboard events (i.e. `Release` and `Repeat`), fixing a Windows-specific issue where crossterm emits multiple `KeyEvent`s per physical keystroke when the kitty keyboard enhancement protocol is active.

- Adds `KeyEventKind` to the `crossterm::event` import.
- Inserts an early `continue` immediately after a `Key` event is read, discarding it if `key.kind != KeyEventKind::Press`.
- The guard is placed before all application-level key handling (both the Milltime re-auth overlay path and the main view dispatch), so every code path benefits from the fix without duplication.
- On non-Windows platforms crossterm only emits `Press` events by default, so the guard is a safe no-op there.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — the change is minimal, well-placed, and follows the standard crossterm pattern for cross-platform key-event filtering.
- The fix is a single, idiomatic guard that is already the recommended approach in the crossterm documentation for handling Windows keyboard events. It touches no business logic, introduces no new state, and is transparent on platforms that only emit `Press` events. No issues found.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| toki-tui/src/main.rs | Imports `KeyEventKind` and adds an early `continue` guard to skip non-`Press` key events, preventing double-firing on Windows where crossterm also emits `Release` and `Repeat` events. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[event::poll] -->|event ready| B[event::read]
    B --> C{Event::Key?}
    C -->|No| D[Skip / next loop iteration]
    C -->|Yes| E{key.kind == Press?}
    E -->|No - Release or Repeat| F[continue - discard event]
    E -->|Yes| G{milltime_reauth overlay open?}
    G -->|Yes| H[Handle re-auth keys]
    G -->|No| I[Handle normal app keys]
```

<sub>Last reviewed commit: 3d07831</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->