### PR TITLE
fix(tui): use rustls-tls for reqwest to avoid OpenSSL dependency on musl

### DIFF
--- a/toki-tui/Cargo.toml
+++ b/toki-tui/Cargo.toml
@@ -14,7 +14,7 @@ throbber-widgets-tui = "0.11"
 tokio = { version = "1", features = ["full"] }
 
 # HTTP client
-reqwest = { version = "0.12", features = ["json", "cookies"] }
+reqwest = { version = "0.12", features = ["json", "cookies", "rustls-tls"], default-features = false }
 
 # Time handling (same as toki-api)
 time = { version = "0.3", features = [


### PR DESCRIPTION
Using the default TLS backend for reqwest requires OpenSSL as a system dependency, which is not always available (e.g. musl builds, minimal Linux environments). Switching to `rustls-tls` with `default-features = false` removes this dependency entirely.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Switches reqwest TLS backend from native-tls (OpenSSL) to rustls-tls by adding `"rustls-tls"` feature and setting `default-features = false`. This removes the system OpenSSL dependency, making the TUI work in musl builds and minimal Linux environments.

- Follows the same pattern already used in the `az-devops` crate
- Retains all required features (`"json"`, `"cookies"`) needed by `api_client.rs`
- No breaking changes - all reqwest functionality used in the codebase works identically with rustls

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Simple dependency configuration change that follows existing patterns in the codebase, requires no code changes, and all required features are properly configured
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| toki-tui/Cargo.toml | Switches reqwest from native-tls to rustls-tls, removing OpenSSL dependency - matches existing pattern in `az-devops` crate |

</details>



<sub>Last reviewed commit: 0ad7680</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->