### PR TITLE
fix(tui): fix activities fetch issue and let backspace key clear input fields for non-running timer

### DIFF
--- a/toki-tui/src/app/mod.rs
+++ b/toki-tui/src/app/mod.rs
@@ -373,6 +373,9 @@ impl App {
                     .iter()
                     .position(|a| self.selected_activity.as_ref().map(|sa| &sa.id) == Some(&a.id))
                     .unwrap_or(0);
+                self.activity_search_input.clear();
+                self.filtered_activities = self.activities.clone();
+                self.filtered_activity_index = 0;
                 self.selection_list_focused = false;
             }
             View::EditDescription => {

--- a/toki-tui/src/app/mod.rs
+++ b/toki-tui/src/app/mod.rs
@@ -194,6 +194,20 @@ impl App {
     }
 
     /// Clear timer and reset to default state
+    /// Clear the selected project and activity (timer must be stopped).
+    pub fn clear_project_activity(&mut self) {
+        self.selected_project = None;
+        self.selected_activity = None;
+        self.status_message = Some("Project and activity cleared".to_string());
+    }
+
+    /// Clear the note/description input (timer must be stopped).
+    pub fn clear_note(&mut self) {
+        self.description_input = TextInput::new();
+        self.description_is_default = true;
+        self.status_message = Some("Note cleared".to_string());
+    }
+
     pub fn clear_timer(&mut self) {
         self.timer_state = TimerState::Stopped;
         self.absolute_start = None;


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed activity fetching in edit mode by refactoring the Enter key handler to async, ensuring activities are fetched from the API when editing entries with projects that aren't in the cache. Also fixed double key event processing by filtering for `KeyEventKind::Press`, cleared activity search state when entering the activity picker, and added Backspace keybinding to clear project/activity or note when the timer is stopped.

**Key changes:**
- Refactored `handle_entry_edit_enter` into async version that fetches activities on-demand using the activity cache
- Added `KeyEventKind::Press` filtering to prevent processing both key press and release events
- Reset activity search input and filtered list when entering SelectActivity view
- Added `clear_project_activity()` and `clear_note()` methods
- Bound Backspace key to clear fields when timer is stopped and appropriate box is focused

<h3>Confidence Score: 5/5</h3>

- Safe to merge - focused bug fixes and UX improvements with no breaking changes
- Clean refactoring that fixes a real bug (activities not being fetched in edit mode), adds proper key event filtering, and improves UX with clear functionality. Changes are well-contained to the TUI module with no impact on other components.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| toki-tui/src/app/mod.rs | Added clear_project_activity() and clear_note() helper methods, fixed activity search state reset when entering activity picker |
| toki-tui/src/main.rs | Fixed key event double-processing, refactored edit-mode Enter handler to async to fetch activities on-demand, added Backspace keybinding to clear fields |

</details>



<sub>Last reviewed commit: 30fa326</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->