### PR TITLE
feat(tui): show lock indicator for locked Milltime time entries

### DIFF
--- a/toki-tui/src/api/dev_backend.rs
+++ b/toki-tui/src/api/dev_backend.rs
@@ -49,6 +49,7 @@ impl DevBackend {
                 start_time: Some(e.start_time),
                 end_time: e.end_time,
                 week_number: e.start_time.iso_week(),
+                attest_level: Default::default(),
             })
             .collect()
     }

--- a/toki-tui/src/runtime/views/history.rs
+++ b/toki-tui/src/runtime/views/history.rs
@@ -110,13 +110,21 @@ pub(super) fn handle_history_key(key: KeyEvent, app: &mut App, action_tx: &Actio
             }
             KeyCode::Char('q') | KeyCode::Char('Q') => app.quit(),
             KeyCode::Delete | KeyCode::Backspace if app.focused_history_index.is_some() => {
-                app.enter_delete_confirm(app::DeleteOrigin::History);
+                if app.focused_history_entry_is_locked() {
+                    app.set_locked_delete_status();
+                } else {
+                    app.enter_delete_confirm(app::DeleteOrigin::History);
+                }
             }
             KeyCode::Char('x')
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && app.focused_history_index.is_some() =>
             {
-                app.enter_delete_confirm(app::DeleteOrigin::History);
+                if app.focused_history_entry_is_locked() {
+                    app.set_locked_delete_status();
+                } else {
+                    app.enter_delete_confirm(app::DeleteOrigin::History);
+                }
             }
             _ => {}
         }

--- a/toki-tui/src/runtime/views/timer.rs
+++ b/toki-tui/src/runtime/views/timer.rs
@@ -95,7 +95,11 @@ pub(super) fn handle_timer_key(key: KeyEvent, app: &mut App, action_tx: &ActionT
                     app.entry_edit_backspace();
                 }
             } else if is_persisted_today_row_selected(app) {
-                app.enter_delete_confirm(app::DeleteOrigin::Timer);
+                if app.focused_this_week_entry_is_locked() {
+                    app.set_locked_delete_status();
+                } else {
+                    app.enter_delete_confirm(app::DeleteOrigin::Timer);
+                }
             }
         }
         KeyCode::Esc => {
@@ -123,7 +127,11 @@ pub(super) fn handle_timer_key(key: KeyEvent, app: &mut App, action_tx: &ActionT
             handle_ctrl_x_key(app, action_tx);
         }
         KeyCode::Delete if !is_editing_this_week(app) && is_persisted_today_row_selected(app) => {
-            app.enter_delete_confirm(app::DeleteOrigin::Timer);
+            if app.focused_this_week_entry_is_locked() {
+                app.set_locked_delete_status();
+            } else {
+                app.enter_delete_confirm(app::DeleteOrigin::Timer);
+            }
         }
         KeyCode::Char('z') | KeyCode::Char('Z') => app.toggle_zen_mode(),
         _ => {}
@@ -233,7 +241,11 @@ fn handle_ctrl_x_key(app: &mut App, action_tx: &ActionTx) {
     }
 
     if is_persisted_today_row_selected(app) {
-        app.enter_delete_confirm(app::DeleteOrigin::Timer);
+        if app.focused_this_week_entry_is_locked() {
+            app.set_locked_delete_status();
+        } else {
+            app.enter_delete_confirm(app::DeleteOrigin::Timer);
+        }
         return;
     }
 

--- a/toki-tui/src/types.rs
+++ b/toki-tui/src/types.rs
@@ -16,6 +16,32 @@ pub struct Activity {
     pub project_id: String,
 }
 
+/// Attestation / lock level for a time entry, matching the Milltime API value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
+#[serde(from = "u8")]
+pub enum AttestLevel {
+    #[default]
+    None = 0,
+    Week = 1,
+    Month = 2,
+}
+
+impl From<u8> for AttestLevel {
+    fn from(v: u8) -> Self {
+        match v {
+            1 => AttestLevel::Week,
+            2 => AttestLevel::Month,
+            _ => AttestLevel::None,
+        }
+    }
+}
+
+impl AttestLevel {
+    pub fn is_locked(self) -> bool {
+        self != AttestLevel::None
+    }
+}
+
 /// A completed time entry from Milltime (via GET /time-tracking/time-entries).
 /// start_time / end_time are optional — present only if a local timer history record exists.
 #[derive(Debug, Clone, Deserialize)]
@@ -36,6 +62,8 @@ pub struct TimeEntry {
     pub end_time: Option<OffsetDateTime>,
     #[allow(dead_code)]
     pub week_number: u8,
+    #[serde(default)]
+    pub attest_level: AttestLevel,
 }
 
 /// The current user, as returned by GET /me.


### PR DESCRIPTION
This pull request introduces support for "locked" time entries by adding an attestation/lock level to entries, preventing editing or deletion of locked items, and updating the UI to visually indicate locked entries. The changes ensure that entries with an attestation level (week or month) cannot be modified, and provide clear feedback to users when such actions are attempted.

**Entry Locking and Attestation Support**

* Added a new `AttestLevel` enum to represent the attestation/lock status of a time entry, with methods for conversion and lock checking. The `TimeEntry` struct now includes an `attest_level` field, and entries default to unlocked unless specified.

**Edit and Delete Guarding**

* Updated edit and delete logic in `App` and runtime view handlers to check if the focused entry is locked before allowing modifications. If locked, a status message is shown and the action is blocked. 
**User Feedback**

* Added status messages for locked entry edit and delete attempts, providing immediate feedback to users when such actions are not permitted. 

**UI Updates**

* Updated the display row logic to show a red "⊘" symbol for locked entries, taking precedence over the warning symbol for overlapping entries, to clearly indicate locked status in the UI.