### PR TITLE
feat(tui): add version and status subcommands, bump to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5666,7 +5666,7 @@ dependencies = [
 
 [[package]]
 name = "toki-tui"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/docs/plans/2026-03-02-tui-version-status-commands.md
+++ b/docs/plans/2026-03-02-tui-version-status-commands.md
@@ -1,0 +1,127 @@
+# toki-tui version + status commands Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `toki-tui version` and `toki-tui status` CLI subcommands and bump the crate version to 0.2.0.
+
+**Architecture:** Two new variants added to the existing `Commands` enum in `cli.rs`, handled in the `match` block in `main.rs`. No new files, no network calls. Version is read at compile time via `env!("CARGO_PKG_VERSION")`. Status is purely local — reads session and Milltime cookie files from disk.
+
+**Tech Stack:** clap 4 (derive), Rust std, existing `session_store` module.
+
+---
+
+### Task 1: Bump crate version to 0.2.0
+
+**Files:**
+- Modify: `toki-tui/Cargo.toml:3`
+
+**Step 1: Edit version field**
+
+Change:
+```toml
+version = "0.1.0"
+```
+To:
+```toml
+version = "0.2.0"
+```
+
+**Step 2: Verify build**
+
+```bash
+SQLX_OFFLINE=true just check
+```
+Expected: `Finished` with no errors.
+
+---
+
+### Task 2: Add `Version` subcommand
+
+**Files:**
+- Modify: `toki-tui/src/cli.rs`
+- Modify: `toki-tui/src/main.rs`
+
+**Step 1: Add variant to Commands enum in `cli.rs`**
+
+```rust
+/// Print the current version
+Version,
+```
+
+**Step 2: Handle in `main.rs` match block**
+
+```rust
+Commands::Version => {
+    println!("{}", env!("CARGO_PKG_VERSION"));
+}
+```
+
+**Step 3: Verify build**
+
+```bash
+SQLX_OFFLINE=true just check
+```
+Expected: `Finished` with no errors.
+
+---
+
+### Task 3: Add `Status` subcommand
+
+**Files:**
+- Modify: `toki-tui/src/cli.rs`
+- Modify: `toki-tui/src/main.rs`
+
+**Step 1: Add variant to Commands enum in `cli.rs`**
+
+```rust
+/// Show current login and Milltime session status
+Status,
+```
+
+**Step 2: Handle in `main.rs` match block**
+
+```rust
+Commands::Status => {
+    let session = session_store::load_session()?;
+    let mt_cookies = session_store::load_mt_cookies()?;
+    let session_status = if session.is_some() { "logged in" } else { "not logged in" };
+    let mt_status = if !mt_cookies.is_empty() { "authenticated" } else { "no cookies" };
+    println!("Session:  {}", session_status);
+    println!("Milltime: {}", mt_status);
+}
+```
+
+**Step 3: Verify build**
+
+```bash
+SQLX_OFFLINE=true just check
+```
+Expected: `Finished` with no errors.
+
+---
+
+### Task 4: Add justfile recipes
+
+**Files:**
+- Modify: `justfile`
+
+**Step 1: Add two recipes after existing tui-* recipes**
+
+```just
+# Print toki-tui version
+tui-version:
+    cd toki-tui && cargo run -- version
+
+# Show toki-tui session status
+tui-status:
+    cd toki-tui && cargo run -- status
+```
+
+---
+
+### Task 5: Commit
+
+```bash
+git add toki-tui/Cargo.toml toki-tui/src/cli.rs toki-tui/src/main.rs justfile docs/plans/2026-03-02-tui-version-status-commands.md
+git commit -m "feat(tui): add version and status subcommands, bump to v0.2.0"
+```

--- a/justfile
+++ b/justfile
@@ -95,3 +95,11 @@ tui-logout:
 # Print TUI config path and create default config if missing
 tui-config:
     cd toki-tui && cargo run -- config-path
+
+# Print toki-tui version
+tui-version:
+    cd toki-tui && cargo run -- version
+
+# Show toki-tui session and Milltime status
+tui-status:
+    cd toki-tui && cargo run -- status

--- a/toki-tui/Cargo.toml
+++ b/toki-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toki-tui"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/toki-tui/src/cli.rs
+++ b/toki-tui/src/cli.rs
@@ -20,4 +20,8 @@ pub enum Commands {
     Logout,
     /// Print config path and create default file if missing
     ConfigPath,
+    /// Print the current version
+    Version,
+    /// Show current login and Milltime session status
+    Status,
 }

--- a/toki-tui/src/main.rs
+++ b/toki-tui/src/main.rs
@@ -28,6 +28,17 @@ async fn main() -> Result<()> {
             let path = config::TokiConfig::ensure_exists()?;
             println!("{}", path.display());
         }
+        Commands::Version => {
+            println!("{}", env!("CARGO_PKG_VERSION"));
+        }
+        Commands::Status => {
+            let session = session_store::load_session()?;
+            let mt_cookies = session_store::load_mt_cookies()?;
+            let session_status = if session.is_some() { "logged in" } else { "not logged in" };
+            let mt_status = if !mt_cookies.is_empty() { "authenticated" } else { "no cookies" };
+            println!("Azure AD: {}", session_status);
+            println!("Milltime: {}", mt_status);
+        }
         Commands::Login => {
             let cfg = config::TokiConfig::load()?;
             login::run_login(&cfg.api_url).await?;


### PR DESCRIPTION
This pull request adds two new CLI subcommands to `toki-tui`: `version` and `status`, and bumps the crate version to 0.2.0. The `version` command prints the current crate version, while the `status` command displays the login and Milltime session status by reading local session data. Additionally, new recipes are added to the `justfile` to invoke these commands easily.

**New CLI features:**

* Added `Version` and `Status` variants to the `Commands` enum in `toki-tui/src/cli.rs`, enabling the new subcommands.
* Implemented handling for the new commands in `toki-tui/src/main.rs`: `Version` prints the version using `env!("CARGO_PKG_VERSION")`, and `Status` checks session and Milltime cookie status.

**Version update:**

* Bumped the crate version from 0.1.0 to 0.2.0 in `toki-tui/Cargo.toml`.

**Developer tooling:**

* Added `tui-version` and `tui-status` recipes to the `justfile` for convenient command execution.

**Documentation:**

* Added a detailed implementation plan in `docs/plans/2026-03-02-tui-version-status-commands.md`, outlining the steps taken in this pull request.