### PR TITLE
[codex] feat(time-tracking): support registered Kleer absence children

### DIFF
--- a/.docs/kleer.md
+++ b/.docs/kleer.md
@@ -68,6 +68,7 @@ Permanent notes for Toki's Kleer time-tracking integration. Read this before cha
 - `POST /company/{companyId}/event/{eventId}`
 - `DELETE /company/{companyId}/event/{eventId}`
 - `GET /company/{companyId}/event/statuses`
+- `GET /company/{companyId}/payroll/user/{userId}`
 - `GET /company/{companyId}/payroll/user/{userId}/schedule/{startDate}/to/{endDate}`
 
 ## Events, Statuses, And Stats
@@ -114,6 +115,12 @@ Permanent notes for Toki's Kleer time-tracking integration. Read this before cha
 - Listing returns projectless events whose activity id maps to one of the resolved absence activities. Project-backed events and unknown projectless events are ignored.
 - Deletion is allowed only for the mapped user’s projectless events with a resolved absence activity id. The adapter fetches the event by id and validates ownership, projectlessness, and activity before calling Kleer delete.
 - `PARENTAL_LEAVE` and `CHILDCARE` require a non-empty child name.
+- Child options come from the mapped Kleer user's payroll employment contract:
+  `GET /payroll/user/{userId}` returns a `children` collection whose child entries
+  have `name` and may omit `birth-date`. The normal event API still writes the
+  child as a string field, so Toki sends the selected registered child name.
+- Kleer's docs also expose `PUT /payroll/user/{userId}/child` to register a child
+  with `name` and `birth-date`, but Toki currently only reads registered children.
 - Normal Kleer event writes send `comment`; send an empty string when the user did not enter one.
 - Use payroll schedule `actual-hours` only as the default per-day absence hours. Missing schedule days default to `0`, and users may manually override hours.
 - Existing same-day absence events are allowed and additive. Kleer remains the source of truth.

--- a/app/src/lib/api/queries/time-tracking.ts
+++ b/app/src/lib/api/queries/time-tracking.ts
@@ -18,6 +18,7 @@ const timeTrackingQueryKeys = {
   timeEntriesBase: ["time-tracking", "time-entries"] as const,
   absenceEntriesBase: ["time-tracking", "absences"] as const,
   absenceTypesBase: ["time-tracking", "absence-types"] as const,
+  absenceChildrenBase: ["time-tracking", "absence-children"] as const,
   absenceDayDefaultsBase: ["time-tracking", "absence-day-defaults"] as const,
   timeInfoBase: ["time-tracking", "time-info"] as const,
   timeEntryDayStatusesBase: [
@@ -115,6 +116,7 @@ export const timeTrackingQueries = {
   timeEntriesBaseKey: timeTrackingQueryKeys.timeEntriesBase,
   absenceEntriesBaseKey: timeTrackingQueryKeys.absenceEntriesBase,
   absenceTypesBaseKey: timeTrackingQueryKeys.absenceTypesBase,
+  absenceChildrenBaseKey: timeTrackingQueryKeys.absenceChildrenBase,
   absenceDayDefaultsBaseKey: timeTrackingQueryKeys.absenceDayDefaultsBase,
   timeInfoBaseKey: timeTrackingQueryKeys.timeInfoBase,
   listProjects: () =>
@@ -203,6 +205,16 @@ export const timeTrackingQueries = {
         api.get("time-tracking/absence-types").json<Array<AbsenceTypeOption>>(),
       staleTime: 60 * 60 * 1000,
       gcTime: 24 * 60 * 60 * 1000,
+    }),
+  absenceChildren: () =>
+    queryOptions({
+      queryKey: timeTrackingQueries.absenceChildrenBaseKey,
+      queryFn: async () =>
+        api
+          .get("time-tracking/absence-children")
+          .json<Array<AbsenceChild>>(),
+      staleTime: 5 * 60 * 1000,
+      gcTime: 60 * 60 * 1000,
     }),
   absenceDayDefaults: (query: DateRangeQuery) =>
     queryOptions({
@@ -357,6 +369,11 @@ export const absenceTypeLabels = {
 export type AbsenceTypeOption = {
   absenceType: ManagedAbsenceType;
   absenceTypeLabel: string;
+};
+
+export type AbsenceChild = {
+  name: string;
+  birthDate: string | null;
 };
 
 export type AbsenceEntry = {

--- a/app/src/routes/_layout/time-tracking/-components/report-absence-dialog.tsx
+++ b/app/src/routes/_layout/time-tracking/-components/report-absence-dialog.tsx
@@ -62,7 +62,7 @@ export function ReportAbsenceDialog(props: {
   const [absenceType, setAbsenceType] =
     React.useState<ManagedAbsenceType | null>(null);
   const [submitAttempted, setSubmitAttempted] = React.useState(false);
-  const [child, setChild] = React.useState("");
+  const [selectedChildName, setSelectedChildName] = React.useState("");
   const [comment, setComment] = React.useState("");
   const [hoursByDate, setHoursByDate] = React.useState<Record<string, string>>(
     {},
@@ -75,6 +75,14 @@ export function ReportAbsenceDialog(props: {
       ...timeTrackingQueries.absenceTypes(),
       enabled: props.open,
     });
+  const {
+    data: absenceChildren = [],
+    isError: isAbsenceChildrenError,
+    isLoading: isAbsenceChildrenLoading,
+  } = useQuery({
+    ...timeTrackingQueries.absenceChildren(),
+    enabled: props.open,
+  });
   const { data: defaults, isLoading: isDefaultsLoading } = useQuery({
     ...timeTrackingQueries.absenceDayDefaults({ from, to }),
     enabled: props.open && dateRangeIsValid,
@@ -103,6 +111,20 @@ export function ReportAbsenceDialog(props: {
     });
   }, [defaults, props.open]);
 
+  const childOptions = React.useMemo(
+    () => {
+      const seen = new Set<string>();
+      return absenceChildren.filter((child) => {
+        if (seen.has(child.name)) return false;
+        seen.add(child.name);
+        return true;
+      });
+    },
+    [absenceChildren],
+  );
+  const selectedChild =
+    childOptions.find((child) => child.name === selectedChildName) ?? null;
+
   const { positiveDays, totalHours } = React.useMemo(() => {
     const days: CreateAbsencesPayload["days"] = [];
     let hours = 0;
@@ -123,6 +145,11 @@ export function ReportAbsenceDialog(props: {
 
   const childRequired =
     absenceType !== null && childRequiredTypes.has(absenceType);
+  const childSelectionReady =
+    !childRequired ||
+    (!isAbsenceChildrenError &&
+      !isAbsenceChildrenLoading &&
+      selectedChild !== null);
   const canAttemptSubmit =
     dateRangeIsValid &&
     positiveDays.length > 0 &&
@@ -130,12 +157,28 @@ export function ReportAbsenceDialog(props: {
     !isAbsenceTypesLoading &&
     !isDefaultsLoading &&
     !props.isCreating &&
-    (!childRequired || child.trim().length > 0);
+    childSelectionReady;
   const canSubmit = Boolean(absenceType) && canAttemptSubmit;
 
   const SelectedTypeIcon = absenceType ? absenceTypeIcons[absenceType] : null;
   const showAbsenceTypeError = submitAttempted && absenceType === null;
+  const showChildError =
+    submitAttempted && childRequired && selectedChild === null;
   const submitDisabled = !canAttemptSubmit;
+
+  React.useEffect(() => {
+    if (!childRequired) {
+      setSelectedChildName("");
+      return;
+    }
+
+    if (
+      selectedChildName &&
+      !childOptions.some((child) => child.name === selectedChildName)
+    ) {
+      setSelectedChildName("");
+    }
+  }, [childOptions, childRequired, selectedChildName]);
 
   const reset = () => {
     const today = getTodayDate();
@@ -143,7 +186,7 @@ export function ReportAbsenceDialog(props: {
     setTo(today);
     setAbsenceType(null);
     setSubmitAttempted(false);
-    setChild("");
+    setSelectedChildName("");
     setComment("");
     setHoursByDate({});
   };
@@ -178,7 +221,7 @@ export function ReportAbsenceDialog(props: {
 
     props.onCreate({
       absenceType,
-      child: childRequired ? child.trim() : null,
+      child: childRequired ? selectedChild?.name ?? null : null,
       comment,
       days: positiveDays,
     });
@@ -298,14 +341,76 @@ export function ReportAbsenceDialog(props: {
               <div className="overflow-hidden p-0.5">
                 <div className="relative">
                   <Baby className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                  <Input
-                    value={child}
-                    onChange={(event) => setChild(event.target.value)}
-                    placeholder="Child name"
-                    className="pl-9"
-                    tabIndex={childRequired ? 0 : -1}
-                  />
+                  <Select
+                    value={selectedChildName}
+                    disabled={
+                      !childRequired ||
+                      isAbsenceChildrenError ||
+                      isAbsenceChildrenLoading ||
+                      absenceChildren.length === 0
+                    }
+                    onValueChange={(value) => {
+                      setSelectedChildName(value);
+                      setSubmitAttempted(false);
+                    }}
+                  >
+                    <SelectTrigger
+                      aria-invalid={showChildError}
+                      aria-describedby={
+                        showChildError ? "absence-child-error" : undefined
+                      }
+                      className={cn(
+                        "pl-9 data-[placeholder]:text-foreground/70",
+                        showChildError &&
+                          "border-destructive focus:ring-destructive",
+                      )}
+                      tabIndex={childRequired ? 0 : -1}
+                    >
+                      <SelectValue
+                        placeholder={
+                          isAbsenceChildrenLoading
+                            ? "Loading children..."
+                            : isAbsenceChildrenError
+                              ? "Could not load children"
+                            : "Select child..."
+                        }
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {childOptions.map((child) => (
+                        <SelectItem
+                          key={`${child.name}:${child.birthDate ?? ""}`}
+                          value={child.name}
+                        >
+                          {child.birthDate
+                            ? `${child.name} - ${dayjs(child.birthDate).format("YYYY-MM-DD")}`
+                            : child.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
+                {childRequired && isAbsenceChildrenError && (
+                  <p className="mt-1.5 text-sm text-destructive">
+                    Could not load registered children from Kleer.
+                  </p>
+                )}
+                {childRequired &&
+                  !isAbsenceChildrenError &&
+                  !isAbsenceChildrenLoading &&
+                  absenceChildren.length === 0 && (
+                    <p className="mt-1.5 text-sm text-muted-foreground">
+                      No registered children found in Kleer.
+                    </p>
+                  )}
+                {showChildError && (
+                  <p
+                    id="absence-child-error"
+                    className="mt-1.5 text-sm text-destructive"
+                  >
+                    Select a registered child to continue.
+                  </p>
+                )}
               </div>
             </div>
           </div>

--- a/kleer/src/client.rs
+++ b/kleer/src/client.rs
@@ -7,8 +7,8 @@ use tracing::{field, Instrument};
 
 use crate::types::{
     KleerActivityList, KleerClientProjectList, KleerEventList, KleerEventReadable,
-    KleerEventRestrictionList, KleerEventWritable, KleerSavedId, KleerScheduleMetadataList,
-    KleerUserList, KleerUserMe,
+    KleerEventRestrictionList, KleerEventWritable, KleerPayrollUserReadable, KleerSavedId,
+    KleerScheduleMetadataList, KleerUserList, KleerUserMe,
 };
 
 pub const DEFAULT_BASE_URL: &str = "https://api.kleer.se/v1";
@@ -185,6 +185,13 @@ impl KleerClient {
             &[],
         )
         .await
+    }
+
+    pub async fn get_payroll_user(
+        &self,
+        user_id: i64,
+    ) -> Result<KleerPayrollUserReadable, KleerError> {
+        self.get(&format!("payroll/user/{user_id}"), &[]).await
     }
 
     async fn get<T>(&self, path: &str, query: &[(&str, String)]) -> Result<T, KleerError>

--- a/kleer/src/types.rs
+++ b/kleer/src/types.rs
@@ -16,6 +16,42 @@ where
     }
 }
 
+fn payroll_children_from_any<'de, D>(deserializer: D) -> Result<Vec<KleerPayrollChild>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    parse_payroll_children_value(value.unwrap_or(serde_json::Value::Null))
+        .map_err(serde::de::Error::custom)
+}
+
+fn parse_payroll_children_value(
+    value: serde_json::Value,
+) -> Result<Vec<KleerPayrollChild>, serde_json::Error> {
+    match value {
+        serde_json::Value::Null => Ok(Vec::new()),
+        serde_json::Value::Array(values) => values
+            .into_iter()
+            .map(parse_payroll_children_value)
+            .collect::<Result<Vec<_>, _>>()
+            .map(|children| children.into_iter().flatten().collect()),
+        serde_json::Value::Object(mut object) => {
+            if let Some(value) = object.remove("child") {
+                return parse_payroll_children_value(value);
+            }
+            if let Some(value) = object.remove("children") {
+                return parse_payroll_children_value(value);
+            }
+            if object.contains_key("name") || object.contains_key("birth-date") {
+                return serde_json::from_value(serde_json::Value::Object(object))
+                    .map(|child| vec![child]);
+            }
+            Ok(Vec::new())
+        }
+        other => serde_json::from_value(other).map(|child| vec![child]),
+    }
+}
+
 mod date_format {
     use serde::{Deserialize, Deserializer, Serializer};
     use time::Date;
@@ -248,6 +284,21 @@ pub struct KleerSavedId {
     pub id: i64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct KleerPayrollChild {
+    pub name: String,
+    #[serde(with = "option_date_format", default)]
+    pub birth_date: Option<Date>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct KleerPayrollUserReadable {
+    #[serde(default, deserialize_with = "payroll_children_from_any")]
+    pub children: Vec<KleerPayrollChild>,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct KleerScheduleMetadata {
@@ -351,5 +402,51 @@ mod tests {
         assert_eq!(parsed.users[0].foreign_id.as_deref(), Some("aad-user-id"));
         assert_eq!(parsed.users[0].internal_id.as_deref(), Some("123"));
         assert_eq!(parsed.users[0].email.as_deref(), Some("ada@example.com"));
+    }
+
+    #[test]
+    fn deserializes_payroll_user_children_collection_shapes() {
+        let raw = r#"{
+            "children": {
+                "child": [
+                    { "name": "Barn1", "birth-date": "2020-01-01" },
+                    { "name": "Barn2", "birth-date": "2022-02-02" }
+                ]
+            }
+        }"#;
+        let parsed: KleerPayrollUserReadable = serde_json::from_str(raw).unwrap();
+
+        assert_eq!(parsed.children.len(), 2);
+        assert_eq!(parsed.children[0].name, "Barn1");
+        assert_eq!(
+            parsed.children[0].birth_date,
+            Some(Date::from_calendar_date(2020, time::Month::January, 1).unwrap())
+        );
+
+        let raw = r#"{
+            "children": {
+                "children": [
+                    { "name": "Barn3", "birth-date": "2023-03-03" }
+                ]
+            }
+        }"#;
+        let parsed: KleerPayrollUserReadable = serde_json::from_str(raw).unwrap();
+        assert_eq!(parsed.children[0].name, "Barn3");
+    }
+
+    #[test]
+    fn deserializes_payroll_user_children_without_birth_date() {
+        let raw = r#"{
+            "children": {
+                "children": [
+                    { "name": "Barn4" }
+                ]
+            }
+        }"#;
+        let parsed: KleerPayrollUserReadable = serde_json::from_str(raw).unwrap();
+
+        assert_eq!(parsed.children.len(), 1);
+        assert_eq!(parsed.children[0].name, "Barn4");
+        assert_eq!(parsed.children[0].birth_date, None);
     }
 }

--- a/toki-api/src/adapters/inbound/http/responses.rs
+++ b/toki-api/src/adapters/inbound/http/responses.rs
@@ -6,10 +6,10 @@ use serde::Serialize;
 use time::OffsetDateTime;
 
 use crate::domain::models::{
-    AbsenceDayDefault, AbsenceEntry, AbsenceType, ActiveTimer, Activity, BoardColumn, BoardData,
-    BoardState, Iteration, Project, PullRequestRef, TimeEntry, TimeEntryDayStatus, TimeEntryStatus,
-    TimerHistoryEntry, WeeklyStats, WorkItem, WorkItemCategory, WorkItemPerson, WorkItemProject,
-    WorkItemRef,
+    AbsenceChild, AbsenceDayDefault, AbsenceEntry, AbsenceType, ActiveTimer, Activity, BoardColumn,
+    BoardData, BoardState, Iteration, Project, PullRequestRef, TimeEntry, TimeEntryDayStatus,
+    TimeEntryStatus, TimerHistoryEntry, WeeklyStats, WorkItem, WorkItemCategory, WorkItemPerson,
+    WorkItemProject, WorkItemRef,
 };
 
 /// Response for the get timer endpoint.
@@ -249,11 +249,28 @@ pub struct AbsenceTypeResponse {
     pub absence_type_label: &'static str,
 }
 
+/// Registered child available for child-related absence reporting.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AbsenceChildResponse {
+    pub name: String,
+    pub birth_date: Option<String>,
+}
+
 impl From<AbsenceType> for AbsenceTypeResponse {
     fn from(absence_type: AbsenceType) -> Self {
         Self {
             absence_type,
             absence_type_label: absence_type.label(),
+        }
+    }
+}
+
+impl From<AbsenceChild> for AbsenceChildResponse {
+    fn from(child: AbsenceChild) -> Self {
+        Self {
+            name: child.name,
+            birth_date: child.birth_date.map(|date| date.to_string()),
         }
     }
 }

--- a/toki-api/src/adapters/outbound/kleer/conversions.rs
+++ b/toki-api/src/adapters/outbound/kleer/conversions.rs
@@ -1,10 +1,13 @@
 use kleer::{
-    KleerActivityReadable, KleerClientProjectReadable, KleerEventReadable, KleerScheduleMetadata,
-    KleerStatusType,
+    KleerActivityReadable, KleerClientProjectReadable, KleerEventReadable, KleerPayrollChild,
+    KleerScheduleMetadata, KleerStatusType,
 };
 
 use crate::domain::{
-    models::{AbsenceEntry, AbsenceType, Activity, Project, ProjectId, TimeEntry, TimeEntryStatus},
+    models::{
+        AbsenceChild, AbsenceEntry, AbsenceType, Activity, Project, ProjectId, TimeEntry,
+        TimeEntryStatus,
+    },
     TimeTrackingError,
 };
 
@@ -74,6 +77,13 @@ pub fn to_domain_time_entry(
 
 pub fn to_domain_scheduled_hours(schedule: &[KleerScheduleMetadata]) -> f64 {
     schedule.iter().map(|day| day.actual_hours).sum()
+}
+
+pub fn to_domain_absence_child(child: KleerPayrollChild) -> AbsenceChild {
+    AbsenceChild {
+        name: child.name,
+        birth_date: child.birth_date,
+    }
 }
 
 pub fn to_domain_absence_entry_from_event(

--- a/toki-api/src/adapters/outbound/kleer/mod.rs
+++ b/toki-api/src/adapters/outbound/kleer/mod.rs
@@ -17,17 +17,17 @@ use time::{Date, Duration};
 
 use crate::domain::{
     models::{
-        AbsenceDayDefault, AbsenceEntry, AbsenceType, Activity, ActivityId, CreateAbsencesRequest,
-        CreateTimeEntryRequest, EditTimeEntryRequest, Project, ProjectId, TimeEntry,
-        TimeEntryDayStatus, TimerId, WeeklyStats,
+        AbsenceChild, AbsenceDayDefault, AbsenceEntry, AbsenceType, Activity, ActivityId,
+        CreateAbsencesRequest, CreateTimeEntryRequest, EditTimeEntryRequest, Project, ProjectId,
+        TimeEntry, TimeEntryDayStatus, TimerId, WeeklyStats,
     },
     ports::outbound::TimeTrackingClient,
     TimeTrackingError,
 };
 
 use self::conversions::{
-    to_domain_absence_entry_from_event, to_domain_activity, to_domain_project,
-    to_domain_scheduled_hours, to_domain_status, to_domain_time_entry,
+    to_domain_absence_child, to_domain_absence_entry_from_event, to_domain_activity,
+    to_domain_project, to_domain_scheduled_hours, to_domain_status, to_domain_time_entry,
 };
 
 pub struct KleerAdapter {
@@ -774,6 +774,22 @@ impl TimeTrackingClient for KleerAdapter {
             .collect())
     }
 
+    async fn get_absence_children(&self) -> Result<Vec<AbsenceChild>, TimeTrackingError> {
+        let payroll_user = self
+            .client
+            .get_payroll_user(self.target_user_id)
+            .await
+            .or_else(default_for_missing_payroll_user)?;
+
+        let mut children: Vec<_> = payroll_user
+            .children
+            .into_iter()
+            .map(to_domain_absence_child)
+            .collect();
+        children.sort_by(|a, b| a.name.cmp(&b.name).then(a.birth_date.cmp(&b.birth_date)));
+        Ok(children)
+    }
+
     async fn get_absences(
         &self,
         date_range: (Date, Date),
@@ -900,6 +916,9 @@ fn map_kleer_error(error: KleerError) -> TimeTrackingError {
         | KleerError::Deserialize { message, .. } => TimeTrackingError::unknown(message),
         KleerError::Response { status, body } => {
             let message = kleer_response_message(&body);
+            if is_single_access_denied_message(&message) {
+                return TimeTrackingError::Forbidden(message);
+            }
             tracing::warn!("Kleer returned non-success response: status={status}, body={message}");
             TimeTrackingError::unknown(format!("Kleer returned {status}: {message}"))
         }
@@ -985,6 +1004,10 @@ fn is_event_access_denied(error: &KleerError) -> bool {
         error,
         KleerError::Response { body, .. } if body.contains("EventAccessDeniedException")
     )
+}
+
+fn is_single_access_denied_message(message: &str) -> bool {
+    message.contains("SingleAccessDeniedException")
 }
 
 #[cfg(test)]
@@ -1370,6 +1393,18 @@ mod tests {
 
         assert!(
             matches!(error, TimeTrackingError::Forbidden(message) if message.contains("EventAccessDeniedException"))
+        );
+    }
+
+    #[test]
+    fn single_access_denied_maps_to_forbidden() {
+        let error = map_kleer_error(KleerError::Response {
+            status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+            body: r#"{"message":"SingleAccessDeniedException: Otillåten access"}"#.to_string(),
+        });
+
+        assert!(
+            matches!(error, TimeTrackingError::Forbidden(message) if message.contains("SingleAccessDeniedException"))
         );
     }
 }

--- a/toki-api/src/domain/models/absence.rs
+++ b/toki-api/src/domain/models/absence.rs
@@ -55,6 +55,12 @@ pub struct AbsenceEntry {
     pub deletable: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbsenceChild {
+    pub name: String,
+    pub birth_date: Option<Date>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct AbsenceDayDefault {
     pub date: Date,

--- a/toki-api/src/domain/ports/inbound/time_tracking.rs
+++ b/toki-api/src/domain/ports/inbound/time_tracking.rs
@@ -3,9 +3,9 @@ use time::Date;
 
 use crate::domain::{
     models::{
-        AbsenceDayDefault, AbsenceEntry, AbsenceType, ActiveTimer, Activity, CreateAbsencesRequest,
-        CreateTimeEntryRequest, EditTimeEntryRequest, Project, ProjectId, TimeEntry,
-        TimeEntryDayStatus, TimerHistoryEntry, UserId, WeeklyStats,
+        AbsenceChild, AbsenceDayDefault, AbsenceEntry, AbsenceType, ActiveTimer, Activity,
+        CreateAbsencesRequest, CreateTimeEntryRequest, EditTimeEntryRequest, Project, ProjectId,
+        TimeEntry, TimeEntryDayStatus, TimerHistoryEntry, UserId, WeeklyStats,
     },
     TimeTrackingError,
 };
@@ -119,6 +119,9 @@ pub trait TimeTrackingService: Send + Sync + 'static {
 
     /// Get available provider-backed absence types.
     async fn get_absence_types(&self) -> Result<Vec<AbsenceType>, TimeTrackingError>;
+
+    /// Get registered children available for child-related absence reporting.
+    async fn get_absence_children(&self) -> Result<Vec<AbsenceChild>, TimeTrackingError>;
 
     /// Get absence entries for a date range.
     async fn get_absences(

--- a/toki-api/src/domain/ports/outbound/time_tracking.rs
+++ b/toki-api/src/domain/ports/outbound/time_tracking.rs
@@ -3,9 +3,9 @@ use time::Date;
 
 use crate::domain::{
     models::{
-        AbsenceDayDefault, AbsenceEntry, AbsenceType, Activity, CreateAbsencesRequest,
-        CreateTimeEntryRequest, EditTimeEntryRequest, Project, ProjectId, TimeEntry,
-        TimeEntryDayStatus, TimerId, WeeklyStats,
+        AbsenceChild, AbsenceDayDefault, AbsenceEntry, AbsenceType, Activity,
+        CreateAbsencesRequest, CreateTimeEntryRequest, EditTimeEntryRequest, Project, ProjectId,
+        TimeEntry, TimeEntryDayStatus, TimerId, WeeklyStats,
     },
     TimeTrackingError,
 };
@@ -75,6 +75,9 @@ pub trait TimeTrackingClient: Send + Sync + 'static {
 
     /// Get available provider-backed absence types.
     async fn get_absence_types(&self) -> Result<Vec<AbsenceType>, TimeTrackingError>;
+
+    /// Get registered children available for child-related absence reporting.
+    async fn get_absence_children(&self) -> Result<Vec<AbsenceChild>, TimeTrackingError>;
 
     /// Get absence entries for a date range.
     async fn get_absences(

--- a/toki-api/src/domain/services/time_tracking.rs
+++ b/toki-api/src/domain/services/time_tracking.rs
@@ -9,9 +9,10 @@ use time::{Date, OffsetDateTime};
 
 use crate::domain::{
     models::{
-        AbsenceDayDefault, AbsenceEntry, AbsenceType, ActiveTimer, Activity, CreateAbsencesRequest,
-        CreateTimeEntryRequest, EditTimeEntryRequest, NewTimerHistoryEntry, Project, ProjectId,
-        TimeEntry, TimeEntryDayStatus, TimeEntryStatus, TimerHistoryEntry, UserId, WeeklyStats,
+        AbsenceChild, AbsenceDayDefault, AbsenceEntry, AbsenceType, ActiveTimer, Activity,
+        CreateAbsencesRequest, CreateTimeEntryRequest, EditTimeEntryRequest, NewTimerHistoryEntry,
+        Project, ProjectId, TimeEntry, TimeEntryDayStatus, TimeEntryStatus, TimerHistoryEntry,
+        UserId, WeeklyStats,
     },
     ports::{
         inbound::TimeTrackingService,
@@ -80,6 +81,14 @@ impl<C, R> TimeTrackingServiceImpl<C, R> {
         .with_status(TimeEntryStatus::Open)
     }
 
+    fn trimmed_child_name(request: &CreateAbsencesRequest) -> Option<&str> {
+        request
+            .child
+            .as_deref()
+            .map(str::trim)
+            .filter(|child| !child.is_empty())
+    }
+
     fn validate_create_absences(request: &CreateAbsencesRequest) -> Result<(), TimeTrackingError> {
         if request.days.is_empty() {
             return Err(TimeTrackingError::InvalidInput(
@@ -87,14 +96,7 @@ impl<C, R> TimeTrackingServiceImpl<C, R> {
             ));
         }
 
-        if request.absence_type.requires_child()
-            && request
-                .child
-                .as_deref()
-                .map(str::trim)
-                .filter(|child| !child.is_empty())
-                .is_none()
-        {
+        if request.absence_type.requires_child() && Self::trimmed_child_name(request).is_none() {
             return Err(TimeTrackingError::InvalidInput(
                 "Child name is required for this absence type".to_string(),
             ));
@@ -118,6 +120,28 @@ impl<C, R> TimeTrackingServiceImpl<C, R> {
                     "Absence hours cannot exceed 24 per day".to_string(),
                 ));
             }
+        }
+
+        Ok(())
+    }
+
+    fn validate_registered_child(
+        requested_child: &str,
+        children: &[AbsenceChild],
+    ) -> Result<(), TimeTrackingError> {
+        if children.is_empty() {
+            return Err(TimeTrackingError::InvalidInput(
+                "Register a child in Kleer before reporting this absence type".to_string(),
+            ));
+        }
+
+        if !children
+            .iter()
+            .any(|registered| registered.name == requested_child)
+        {
+            return Err(TimeTrackingError::InvalidInput(
+                "Select a registered child for this absence type".to_string(),
+            ));
         }
 
         Ok(())
@@ -408,6 +432,10 @@ impl<C: TimeTrackingClient, R: TimerHistoryRepository> TimeTrackingService
         self.client.get_absence_types().await
     }
 
+    async fn get_absence_children(&self) -> Result<Vec<AbsenceChild>, TimeTrackingError> {
+        self.client.get_absence_children().await
+    }
+
     async fn get_absence_day_defaults(
         &self,
         date_range: (Date, Date),
@@ -425,6 +453,12 @@ impl<C: TimeTrackingClient, R: TimerHistoryRepository> TimeTrackingService
             return Err(TimeTrackingError::InvalidInput(
                 "This absence type is not available in Kleer".to_string(),
             ));
+        }
+        if request.absence_type.requires_child() {
+            let child = Self::trimmed_child_name(request)
+                .expect("create_absences validates child-related absences before child lookup");
+            let children = self.client.get_absence_children().await?;
+            Self::validate_registered_child(child, &children)?;
         }
         self.client.create_absences(request).await
     }
@@ -452,6 +486,7 @@ mod tests {
     struct MockTimeTrackingClient {
         created_request: Mutex<Option<CreateTimeEntryRequest>>,
         absence_types: Vec<AbsenceType>,
+        absence_children: Vec<AbsenceChild>,
     }
 
     #[async_trait]
@@ -510,6 +545,10 @@ mod tests {
 
         async fn get_absence_types(&self) -> Result<Vec<AbsenceType>, TimeTrackingError> {
             Ok(self.absence_types.clone())
+        }
+
+        async fn get_absence_children(&self) -> Result<Vec<AbsenceChild>, TimeTrackingError> {
+            Ok(self.absence_children.clone())
         }
 
         async fn get_absences(
@@ -721,6 +760,7 @@ mod tests {
         let client = Arc::new(MockTimeTrackingClient {
             created_request: Mutex::new(None),
             absence_types: vec![AbsenceType::Vacation],
+            absence_children: Vec::new(),
         });
         let repo = Arc::new(MockTimerHistoryRepository {
             active_timer: Mutex::new(None),
@@ -740,6 +780,39 @@ mod tests {
 
         assert!(
             matches!(error, TimeTrackingError::InvalidInput(message) if message == "This absence type is not available in Kleer")
+        );
+    }
+
+    #[test]
+    fn registered_child_validation_requires_matching_child() {
+        let date = Date::from_calendar_date(2026, time::Month::May, 20).unwrap();
+        let request = CreateAbsencesRequest {
+            absence_type: AbsenceType::Childcare,
+            child: Some("Barn1".to_string()),
+            comment: String::new(),
+            days: vec![CreateAbsenceDay { date, hours: 8.0 }],
+        };
+        let children = vec![AbsenceChild {
+            name: "Barn1".to_string(),
+            birth_date: Some(date),
+        }];
+
+        let child = TimeTrackingServiceImpl::<MockTimeTrackingClient, MockTimerHistoryRepository>::trimmed_child_name(&request).unwrap();
+        assert!(TimeTrackingServiceImpl::<MockTimeTrackingClient, MockTimerHistoryRepository>::validate_registered_child(child, &children).is_ok());
+
+        let error = TimeTrackingServiceImpl::<MockTimeTrackingClient, MockTimerHistoryRepository>::validate_registered_child(child, &[])
+            .unwrap_err();
+        assert!(
+            matches!(error, TimeTrackingError::InvalidInput(message) if message == "Register a child in Kleer before reporting this absence type")
+        );
+
+        let error = TimeTrackingServiceImpl::<MockTimeTrackingClient, MockTimerHistoryRepository>::validate_registered_child(
+            "Other",
+            &children,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(error, TimeTrackingError::InvalidInput(message) if message == "Select a registered child for this absence type")
         );
     }
 }

--- a/toki-api/src/routes/time_tracking/absences.rs
+++ b/toki-api/src/routes/time_tracking/absences.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 
 use crate::{
     adapters::inbound::http::{
-        AbsenceDayDefaultResponse, AbsenceEntryResponse, AbsenceTypeResponse,
+        AbsenceChildResponse, AbsenceDayDefaultResponse, AbsenceEntryResponse, AbsenceTypeResponse,
     },
     app_state::AppState,
     auth::AuthUser,
@@ -47,6 +47,21 @@ pub async fn get_absence_types(
     let types = service.get_absence_types().await?;
 
     Ok(Json(types.into_iter().map(Into::into).collect()))
+}
+
+pub async fn get_absence_children(
+    user: AuthUser,
+    State(app_state): State<AppState>,
+) -> Result<Json<Vec<AbsenceChildResponse>>, ApiError> {
+    record_user_id(user.id);
+    let service = app_state
+        .time_tracking_factory
+        .create_service(user.id)
+        .await?;
+
+    let children = service.get_absence_children().await?;
+
+    Ok(Json(children.into_iter().map(Into::into).collect()))
 }
 
 pub async fn get_absences(

--- a/toki-api/src/routes/time_tracking/mod.rs
+++ b/toki-api/src/routes/time_tracking/mod.rs
@@ -37,6 +37,7 @@ pub fn router() -> Router<AppState> {
             get(absences::get_absence_day_defaults),
         )
         .route("/absence-types", get(absences::get_absence_types))
+        .route("/absence-children", get(absences::get_absence_children))
         .route(
             "/time-entry-day-statuses",
             get(calendar::get_time_entry_day_statuses),


### PR DESCRIPTION
## Summary

Adds support for registered Kleer children in child-related absence reporting.

- Adds a provider-agnostic absence child model, port, and API endpoint.
- Reads registered children from Kleer's payroll user data and validates child-related absences against that list.
- Updates the absence dialog to select a registered child instead of accepting arbitrary text.
- Documents the relevant Kleer child API behavior.

## Validation

- `SQLX_OFFLINE=true just check`
- `just tsc`
- `just lint`
- `cargo test -p kleer deserializes_payroll_user_children_collection_shapes`
- `SQLX_OFFLINE=true cargo test -p toki-api registered_child_validation_requires_matching_child`